### PR TITLE
fix(hyprland): replace deprecated togglesplit with layoutmsg

### DIFF
--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -499,7 +499,7 @@ in
               "$mainMod SHIFT, Q, exit,"
               "$mainMod, V, togglefloating,"
               "$mainMod, P, exec, wlogout -b 3 -c 60 -r 60"
-              "$mainMod, J, togglesplit,"
+              "$mainMod, J, layoutmsg, togglesplit"
               "$mainMod SHIFT, E, exec, hypr-equalize-windows"
               "$mainMod, F, fullscreen, 0"
               "$mainMod, R, submap, resize"


### PR DESCRIPTION
## Summary
- Hyprland 0.54+ removed the `togglesplit` dispatcher (`removed - use layoutmsg`)
- Updated SUPER+J binding to use `layoutmsg, togglesplit` instead
- Verified working via `hyprctl dispatch layoutmsg togglesplit`

Closes #3

## Test plan
- [x] Rebuild with updated flake
- [x] Press SUPER+J to confirm window split orientation toggles