### PR TITLE
fix(hyprshell): launch from hyprland exec-once to win env race

### DIFF
--- a/modules/desktop/hyprshell/default.nix
+++ b/modules/desktop/hyprshell/default.nix
@@ -22,6 +22,17 @@ in
           enable = true;
           package = pkgs.hyprshell;
 
+          # Disable the home-manager systemd user service. It binds to
+          # graphical-session.target, which activates before Hyprland's
+          # exec-once runs `dbus-update-activation-environment`. Hyprshell
+          # then starts without HYPRLAND_INSTANCE_SIGNATURE in its
+          # environment, fails to locate the Hyprland IPC socket, gives up
+          # after ~25s, and falls back to default keybinds (breaking the
+          # configured alt-tab and printing "Could not get socket path!").
+          # Starting hyprshell from Hyprland exec-once below guarantees the
+          # env is fully populated before the daemon launches.
+          systemd.enable = false;
+
           # Settings are passed as JSON value (not type-safe like flake version)
           settings = {
             windows = {
@@ -41,6 +52,13 @@ in
           # Matches Hyprland active/inactive window border colors
           style = stylix.mkStyle ./style.nix;
         };
+
+        # mkAfter ensures this runs after the hyprland module's
+        # dbus-update-activation-environment exec-once entry so the env is
+        # propagated to the process.
+        wayland.windowManager.hyprland.settings.exec-once = lib.mkAfter [
+          "${pkgs.hyprshell}/bin/hyprshell run"
+        ];
       })
     ];
   };


### PR DESCRIPTION
## Summary

- Disables the home-manager `services.hyprshell` systemd user service and instead launches `hyprshell run` from Hyprland's `exec-once` so the child process inherits the compositor's environment directly.

## Background

The home-manager `services.hyprshell` unit binds to `graphical-session.target`, which activates **before** Hyprland's `exec-once` runs `dbus-update-activation-environment --systemd ... HYPRLAND_INSTANCE_SIGNATURE`. Hyprshell starts without that env var, fails to find the Hyprland IPC socket, retries for ~25s, then falls back to default keybinds. Visible symptoms on a fresh boot:

- Notification: *"Failed to configure wm: Failed to apply open keybinds for windows"*
- Notification: *"Unable to load hyprland plugin, restart hyprland if you updated"*
- Journal: `Could not get socket path! (Is Hyprland running??)`
- Configured alt-tab silently uses defaults instead of the module's settings.

Re-running `systemctl --user restart hyprshell.service` clears it (env is fully populated by then), confirming the race.

Launching from `exec-once` with `lib.mkAfter` means the hyprshell child is forked from the running Hyprland process, so `HYPRLAND_INSTANCE_SIGNATURE` is always present.

## Test plan

- [x] `nix eval ... .#nixosConfigurations.<host>.config.home-manager.users.<user>.wayland.windowManager.hyprland.settings.exec-once` includes `${pkgs.hyprshell}/bin/hyprshell run` after `dbus-update-activation-environment`.
- [x] `services.hyprshell` no longer generates a systemd user unit (`nixosConfigurations.<host>.config.home-manager.users.<user>.systemd.user.services.hyprshell` evaluates to missing).
- [ ] Reboot host, confirm hyprshell starts cleanly with no `Could not get socket path` warnings and alt-tab uses the configured `modifier = "alt"` switcher.