### PR TITLE
chore: pin hyprland configType=hyprlang before stateVersion 26.05

### DIFF
--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -406,6 +406,10 @@ in
 
           wayland.windowManager.hyprland = {
             enable = true;
+            # Pin to legacy hyprlang backend. home-manager flips this default to
+            # "lua" once home.stateVersion >= "26.05"; the module body is written
+            # in hyprlang style, so pin explicitly until a lua migration audit.
+            configType = "hyprlang";
             # Use packages from NixOS module to avoid conflicts
             package = null;
             portalPackage = null;


### PR DESCRIPTION
## Summary
Closes #11: chore: pin hyprland configType=hyprlang before stateVersion 26.05

- chore(hyprland): pin configType to hyprlang
  home-manager flips wayland.windowManager.hyprland.configType from
  "hyprlang" to "lua" once home.stateVersion >= "26.05". The module body
  is written in hyprlang style (settings, extraConfig), so a downstream
  stateVersion bump would silently switch rendering. Pin explicitly until
  the lua migration audit is done.
  
  Closes #11