### PR TITLE
feat!: replace GDM with DankGreeter (greetd) as the sole login manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ temp.sh
 # Python bytecode
 __pycache__/
 *.pyc
+.worktree-state.json
+.worktree.lock
+PLAN.md

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Batteries-included Hyprland desktop for NixOS. Add one module, get complete desk
   a single process. Always enabled — hyprflake's core shell.
 - **Stylix** - System-wide theming
 - **PipeWire** - Audio stack
-- **GDM** - Login manager
+- **DankGreeter** - greetd login manager, themed from the DMS shell config
 - **Fonts** - Curated collection (Apple SF family via apple-fonts)
 - **Keyring** - Secret management with auto-unlock
 - **XDG** - Portal support
@@ -241,7 +241,7 @@ hyprflake/
 │   │   ├── dank/              # DankMaterialShell — the core shell (bar,
 │   │   │                      #   launcher, notifications, OSD, power menu,
 │   │   │                      #   lock, idle); always enabled, no toggle
-│   │   ├── display-manager/   # GDM (Wayland session)
+│   │   ├── display-manager/   # DankGreeter (greetd) login manager
 │   │   ├── gtk/               # GTK theming (icons via Stylix)
 │   │   ├── hyprland/          # Compositor + keybinds (dispatch to dms ipc)
 │   │   ├── kitty/             # Terminal

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,8 @@ modules/
     dank/                 # DankMaterialShell desktop shell (bar, launcher,
                           # notifications, OSD, power menu, lock, idle).
                           # hyprflake's core shell; always enabled, no toggle.
-    display-manager/      # GDM display manager + xkb keyboard config
+    display-manager/      # Login backend: GDM (default) or DankGreeter on greetd,
+                          # selected by hyprflake.desktop.displayManager.backend
     gtk/                  # GTK icon theme configuration
     hyprland/             # Core Hyprland config, keybinds, env vars, window rules.
                           # Also defines hyprflake.desktop.keyboard + terminal options.
@@ -128,6 +129,14 @@ a bar widget / a setting; (2) does DMS do it but it isn't wired? wire it;
 (3) only if DMS genuinely lacks it (or coverage is unverified) add a standalone
 tool, and record why. Reasons to keep a standalone tool decay as DMS evolves —
 revisit them on DMS bumps.
+
+The login screen extends this past the shell. `displayManager.backend =
+"dms-greeter"` runs DankMaterialShell's greetd greeter, themed from the same
+Stylix-controlled DMS config via the greeter's `configHome` copy, so the login
+screen and the shell share one theme. It is a selectable backend, not the
+default yet: GDM stays in the tree as `backend = "gdm"` for rollback. Login-time
+keyring auto-unlock follows the backend through PAM (greetd vs gdm); the
+gnome-keyring + gcr-ssh-agent stack is unchanged.
 
 **Current standing exceptions (DMS does not cover these well yet):**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,8 +14,8 @@ modules/
     dank/                 # DankMaterialShell desktop shell (bar, launcher,
                           # notifications, OSD, power menu, lock, idle).
                           # hyprflake's core shell; always enabled, no toggle.
-    display-manager/      # Login backend: GDM (default) or DankGreeter on greetd,
-                          # selected by hyprflake.desktop.displayManager.backend
+    display-manager/      # DankGreeter (greetd) login manager. GDM removed;
+                          # toggle with hyprflake.desktop.displayManager.enable
     gtk/                  # GTK icon theme configuration
     hyprland/             # Core Hyprland config, keybinds, env vars, window rules.
                           # Also defines hyprflake.desktop.keyboard + terminal options.
@@ -130,13 +130,13 @@ a bar widget / a setting; (2) does DMS do it but it isn't wired? wire it;
 tool, and record why. Reasons to keep a standalone tool decay as DMS evolves —
 revisit them on DMS bumps.
 
-The login screen extends this past the shell. `displayManager.backend =
-"dms-greeter"` runs DankMaterialShell's greetd greeter, themed from the same
-Stylix-controlled DMS config via the greeter's `configHome` copy, so the login
-screen and the shell share one theme. It is a selectable backend, not the
-default yet: GDM stays in the tree as `backend = "gdm"` for rollback. Login-time
-keyring auto-unlock follows the backend through PAM (greetd vs gdm); the
-gnome-keyring + gcr-ssh-agent stack is unchanged.
+The login screen extends this past the shell. The display manager is
+DankMaterialShell's greetd greeter, themed from the same Stylix-controlled DMS
+config via the greeter's `configHome` copy, so the login screen and the shell
+share one theme. GDM was removed outright (no in-tree fallback; roll back with
+`backup/pre-dank-baseline` or a previous generation). Login-time keyring
+auto-unlock rides on the `greetd` PAM service; the gnome-keyring + gcr-ssh-agent
+stack is unchanged.
 
 **Current standing exceptions (DMS does not cover these well yet):**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,8 +14,8 @@ modules/
     dank/                 # DankMaterialShell desktop shell (bar, launcher,
                           # notifications, OSD, power menu, lock, idle).
                           # hyprflake's core shell; always enabled, no toggle.
-    display-manager/      # DankGreeter (greetd) login manager. GDM removed;
-                          # toggle with hyprflake.desktop.displayManager.enable
+    display-manager/      # DankGreeter (greetd) login manager. GDM removed.
+                          # Core, always-on, no toggle (like the DMS shell).
     gtk/                  # GTK icon theme configuration
     hyprland/             # Core Hyprland config, keybinds, env vars, window rules.
                           # Also defines hyprflake.desktop.keyboard + terminal options.

--- a/docs/keyring.md
+++ b/docs/keyring.md
@@ -8,7 +8,7 @@ This configuration provides:
 
 ### 🔓 Automatic Keyring Unlock
 
-- **At login:** Keyring unlocks with your GDM password
+- **At login:** Keyring unlocks with your DankGreeter (greetd) password
 - **At screen unlock:** Keyring unlocks with your DankMaterialShell lock screen password
 
 ### 🔑 SSH Key Management
@@ -53,7 +53,7 @@ if you declare one). So `login.enableGnomeKeyring = true` in
 `security.pam.services` is what re-unlocks the keyring on screen unlock.
 
 - Desktop environments (GNOME, KDE) configure this automatically
-- Tiling WM users configure GDM login (works) but forget the lock-screen PAM
+- Tiling WM users configure greetd login (works) but forget the lock-screen PAM
   service (breaks)
 - Symptoms only appear after first screen lock, not immediately
 - Very confusing to debug without understanding PAM flow
@@ -65,7 +65,7 @@ if you declare one). So `login.enableGnomeKeyring = true` in
 ```
 Boot
   ↓
-GDM Login with password
+greetd login with password
   ↓
 PAM starts gnome-keyring-daemon and unlocks it with login password
   ↓
@@ -114,9 +114,8 @@ Resume work seamlessly
 
 ```nix
 security.pam.services = {
-  gdm.enableGnomeKeyring = true;
-  gdm-password.enableGnomeKeyring = true;
-  login.enableGnomeKeyring = true;  # Also covers the DMS lock screen on NixOS
+  greetd.enableGnomeKeyring = true;   # DankGreeter login auto-unlock
+  login.enableGnomeKeyring = true;    # Also covers the DMS lock screen on NixOS
 };
 ```
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -83,6 +83,26 @@ Desktop environment behavior and input settings.
 | `desktop.keyboard.layout`  | `string` | `"us"`  | Keyboard layout (can be comma-separated: "us,de") |
 | `desktop.keyboard.variant` | `string` | `""`    | Keyboard variant (e.g., "colemak", "dvorak")      |
 
+### Display Manager
+
+| Option                              | Type                          | Default | Description                                                        |
+| ----------------------------------- | ----------------------------- | ------- | ----------------------------------------------------------------- |
+| `desktop.displayManager.enable`     | `bool`                        | `true`  | Configure a login display manager                                 |
+| `desktop.displayManager.backend`    | `enum "gdm" \| "dms-greeter"` | `"gdm"` | Which login backend to use (see below)                            |
+
+`backend = "gdm"` is the historical default and carries the GDM 50 /
+gnome-session workarounds (see `docs/workarounds.md`). `backend = "dms-greeter"`
+switches to DankMaterialShell's greetd-based greeter, themed from the same
+Stylix-controlled DMS config as the shell via the greeter's `configHome` copy
+(no matugen). Both code paths stay in the tree, so reverting is a one-line flip
+plus rebuild.
+
+Keyring auto-unlock follows the backend: the `pam_gnome_keyring` hook is on
+`gdm`/`gdm-password` for GDM and on `greetd` for DankGreeter (see
+`modules/system/keyring`). Auto-unlock without a second prompt needs the login
+password to equal the login-keyring password. The keyring stack itself
+(gnome-keyring + gcr-ssh-agent) is unchanged across backends.
+
 ### Desktop Shell (DankMaterialShell)
 
 The desktop shell is [DankMaterialShell](https://github.com/AvengeMedia/DankMaterialShell)

--- a/docs/options.md
+++ b/docs/options.md
@@ -97,6 +97,13 @@ Stylix-controlled DMS config as the shell via the greeter's `configHome` copy
 (no matugen). Both code paths stay in the tree, so reverting is a one-line flip
 plus rebuild.
 
+The greeter theme is copied from the user's exported DMS state
+(`settings.json`, `dms-colors.json`), which only exists after the user has run
+DMS at least once. On a fresh machine before the first DMS launch, the login
+screen falls back to the default DMS theme. It is unthemed, not broken. The
+config is read from the user's declared home (`users.users.<name>.home`), so
+impermanence and home overrides resolve correctly.
+
 Keyring auto-unlock follows the backend: the `pam_gnome_keyring` hook is on
 `gdm`/`gdm-password` for GDM and on `greetd` for DankGreeter (see
 `modules/system/keyring`). Auto-unlock without a second prompt needs the login

--- a/docs/options.md
+++ b/docs/options.md
@@ -85,17 +85,19 @@ Desktop environment behavior and input settings.
 
 ### Display Manager
 
-| Option                              | Type                          | Default | Description                                                        |
-| ----------------------------------- | ----------------------------- | ------- | ----------------------------------------------------------------- |
-| `desktop.displayManager.enable`     | `bool`                        | `true`  | Configure a login display manager                                 |
-| `desktop.displayManager.backend`    | `enum "gdm" \| "dms-greeter"` | `"gdm"` | Which login backend to use (see below)                            |
+| Option                          | Type   | Default | Description                                       |
+| ------------------------------- | ------ | ------- | ------------------------------------------------- |
+| `desktop.displayManager.enable` | `bool` | `true`  | Configure the DankGreeter (greetd) login manager  |
 
-`backend = "gdm"` is the historical default and carries the GDM 50 /
-gnome-session workarounds (see `docs/workarounds.md`). `backend = "dms-greeter"`
-switches to DankMaterialShell's greetd-based greeter, themed from the same
-Stylix-controlled DMS config as the shell via the greeter's `configHome` copy
-(no matugen). Both code paths stay in the tree, so reverting is a one-line flip
-plus rebuild.
+The login manager is DankMaterialShell's greetd-based greeter (DankGreeter).
+GDM was removed in favour of it, so the login screen and the shell share one
+Stylix-controlled theme via the greeter's `configHome` copy (no matugen), and
+the GDM 50 / gnome-session workaround stack is gone. Set `enable = false` to
+run your own login manager instead. There is no in-tree GDM fallback; roll back
+with the `backup/pre-dank-baseline` branch or a previous NixOS generation.
+
+`hyprflake.user.username` must be set (and that user declared in `users.users`)
+so the greeter can read the user's home for `configHome`.
 
 The greeter theme is copied from the user's exported DMS state
 (`settings.json`, `dms-colors.json`), which only exists after the user has run
@@ -104,18 +106,18 @@ screen falls back to the default DMS theme. It is unthemed, not broken. The
 config is read from the user's declared home (`users.users.<name>.home`), so
 impermanence and home overrides resolve correctly.
 
-Keyring auto-unlock follows the backend: the `pam_gnome_keyring` hook is on
-`gdm`/`gdm-password` for GDM and on `greetd` for DankGreeter (see
-`modules/system/keyring`). Auto-unlock without a second prompt needs the login
-password to equal the login-keyring password. The keyring stack itself
-(gnome-keyring + gcr-ssh-agent) is unchanged across backends.
+Keyring auto-unlock: the `pam_gnome_keyring` hook is on the `greetd` PAM service
+(see `modules/system/keyring`), plus `login` for the DMS lock-screen re-unlock.
+Auto-unlock without a second prompt needs the login password to equal the
+login-keyring password. The keyring stack itself (gnome-keyring + gcr-ssh-agent)
+is unchanged.
 
-Security note for `dms-greeter`: the greeter's root `preStart` copies file
-paths referenced in your DMS `settings.json` / `session.json` (theme file,
-wallpapers) into `/var/lib/dms-greeter` and makes them readable by the
-unprivileged `greeter` user. Any path placed in those files is followed by
-root, so do not point DMS theme or wallpaper settings at secrets. This is
-upstream greeter behavior, tracked in `docs/workarounds.md`.
+Security note: the greeter's root `preStart` copies file paths referenced in
+your DMS `settings.json` / `session.json` (theme file, wallpapers) into
+`/var/lib/dms-greeter` and makes them readable by the unprivileged `greeter`
+user. Any path placed in those files is followed by root, so do not point DMS
+theme or wallpaper settings at secrets. This is upstream greeter behavior,
+tracked in `docs/workarounds.md`.
 
 ### Desktop Shell (DankMaterialShell)
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -110,6 +110,13 @@ Keyring auto-unlock follows the backend: the `pam_gnome_keyring` hook is on
 password to equal the login-keyring password. The keyring stack itself
 (gnome-keyring + gcr-ssh-agent) is unchanged across backends.
 
+Security note for `dms-greeter`: the greeter's root `preStart` copies file
+paths referenced in your DMS `settings.json` / `session.json` (theme file,
+wallpapers) into `/var/lib/dms-greeter` and makes them readable by the
+unprivileged `greeter` user. Any path placed in those files is followed by
+root, so do not point DMS theme or wallpaper settings at secrets. This is
+upstream greeter behavior, tracked in `docs/workarounds.md`.
+
 ### Desktop Shell (DankMaterialShell)
 
 The desktop shell is [DankMaterialShell](https://github.com/AvengeMedia/DankMaterialShell)

--- a/docs/options.md
+++ b/docs/options.md
@@ -116,9 +116,11 @@ impermanence and home overrides resolve correctly.
 
 Keyring auto-unlock: the `pam_gnome_keyring` hook is on the `greetd` PAM service
 (see `modules/system/keyring`), plus `login` for the DMS lock-screen re-unlock.
-Auto-unlock without a second prompt needs the login password to equal the
-login-keyring password. The keyring stack itself (gnome-keyring + gcr-ssh-agent)
-is unchanged.
+The `greetd` hook is attached whenever `services.greetd.enable` is true, which
+hyprflake always sets via the greeter, so it tracks the service rather than being
+forced on. Auto-unlock without a second prompt needs the login password to equal
+the login-keyring password. The keyring stack itself (gnome-keyring +
+gcr-ssh-agent) is unchanged.
 
 Security note: the greeter's root `preStart` copies file paths referenced in
 your DMS `settings.json` / `session.json` (theme file, wallpapers) into

--- a/docs/options.md
+++ b/docs/options.md
@@ -85,19 +85,27 @@ Desktop environment behavior and input settings.
 
 ### Display Manager
 
-| Option                          | Type   | Default | Description                                       |
-| ------------------------------- | ------ | ------- | ------------------------------------------------- |
-| `desktop.displayManager.enable` | `bool` | `true`  | Configure the DankGreeter (greetd) login manager  |
-
 The login manager is DankMaterialShell's greetd-based greeter (DankGreeter).
-GDM was removed in favour of it, so the login screen and the shell share one
-Stylix-controlled theme via the greeter's `configHome` copy (no matugen), and
-the GDM 50 / gnome-session workaround stack is gone. Set `enable = false` to
-run your own login manager instead. There is no in-tree GDM fallback; roll back
-with the `backup/pre-dank-baseline` branch or a previous NixOS generation.
+It is core infrastructure with no enable option, the same as the DMS shell:
+always present, always the login path. GDM was removed in favour of it, so the
+login screen and the shell share one Stylix-controlled theme via the greeter's
+`configHome` copy (no matugen), and the GDM 50 / gnome-session workaround stack
+is gone. To run a different login manager, override `services.greetd` or
+`programs.dank-material-shell.greeter` directly. There is no in-tree GDM
+fallback; roll back with the `backup/pre-dank-baseline` branch or a previous
+NixOS generation.
 
-`hyprflake.user.username` must be set (and that user declared in `users.users`)
-so the greeter can read the user's home for `configHome`.
+Set `hyprflake.user.username` (and declare that user in `users.users`) so the
+greeter can read the user's home for `configHome` theming and resolve the login
+avatar. Without it the greeter still logs you in, just with the default theme
+and no avatar, and the build emits a warning saying so. The keyboard layout
+from `hyprflake.desktop.keyboard` is propagated to the greeter automatically.
+
+To set the login avatar, point `hyprflake.user.photo` at an image. The
+`system/user` module copies it to `/var/lib/AccountsService/icons/<username>`,
+which is one of the paths the greeter probes for each user's face (after its own
+`dms greeter sync` cache, before `~/.face`). No imperative `dms greeter sync`
+step is needed; the AccountsService path is declarative and NixOS-native.
 
 The greeter theme is copied from the user's exported DMS state
 (`settings.json`, `dms-colors.json`), which only exists after the user has run

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -20,10 +20,14 @@ says it's safe to remove.
   (`customThemeFile`, `wallpaperPath*`, `monitorWallpapers*`) into
   `/var/lib/dms-greeter` and runs `chown greeter:` over the result
   (assuming the default `greeter` greetd session user, which hyprflake
-  does not override). Any path written into those JSON files is followed
-  by root and the copy is handed to the unprivileged `greeter` user. The `customThemeFile` copy
-  is also how Stylix theming reaches the greeter, so it cannot simply be
-  dropped without losing the themed login screen.
+  does not override). The `cp` does not pass `-P`, so a symlink in those
+  keys is dereferenced: the example generalizes from "a key file" to any
+  root-readable path the symlink points at. Any path written into those
+  JSON files is followed by root, and the copy lands mode-0750 owned by
+  the distinct, unprivileged `greeter` service account, not just back to
+  the user who wrote the config. The `customThemeFile` copy is also how
+  Stylix theming reaches the greeter, so it cannot simply be dropped
+  without losing the themed login screen.
 - **Impact:** bounded under the single-user threat model. The writer of
   the DMS config is the primary user, so the realistic risk is something
   running as that user planting a root-only path (e.g. a key file) and

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -5,16 +5,15 @@ the fix location, the upstream issue/PR to watch, and the signal that
 says it's safe to remove.
 
 **Revisit on every `nixpkgs` bump** — especially when the bump touches
-`nixos/modules/services/display-managers/gdm.nix`, the `gnome-session`
-package, or `hyprpolkitagent`.
+`greetd`, `hyprpolkitagent`, or the `dank-material-shell` greeter input.
 
 ---
 
 ## DankGreeter preStart exposes user config paths to the `greeter` user
 
 - **Symptom:** none at runtime. This is a security exposure, not a
-  visible failure, and it only applies when
-  `hyprflake.desktop.displayManager.backend = "dms-greeter"`.
+  visible failure. It applies whenever the DankGreeter is the login
+  manager (`hyprflake.desktop.displayManager.enable`, the default).
 - **Cause:** the upstream greeter's `greetd` `preStart` runs as root,
   reads the user's `settings.json` / `session.json` (synced via
   `configHome`), then copies the file paths they reference
@@ -40,71 +39,30 @@ package, or `hyprpolkitagent`.
 
 ---
 
-## GDM 50 greeter cannot find `gnome-session`
+## `hyprpolkitagent` autostarts in the greetd greeter and ABRTs
 
-- **Symptom:** post-boot, blank login screen. Journal:
-  `gdm-wayland-session[...]: Unable to run session`.
-- **Cause:** GDM 50's greeter session file ships `Exec=gnome-session`,
-  but nixpkgs' `gdm.nix` only adds `pkgs.gnome-session` to the
-  display-manager service's `PATH=` env, not to
-  `environment.systemPackages`. The `gdm-greeter` user therefore can't
-  find the binary.
-- **Fix:** `modules/desktop/display-manager/default.nix` —
-  `environment.systemPackages = [ pkgs.gnome-session ];`
-- **Upstream:** no nixpkgs issue filed yet (PR opportunity).
-- **Remove when:** nixpkgs `gdm.nix` adds `pkgs.gnome-session` to its
-  own `environment.systemPackages` (currently it only adds
-  `adwaita-icon-theme` and `pkgs.gdm`).
-
----
-
-## GDM 50 greeter cannot find `gnome-login.session`
-
-- **Symptom:** post-boot, blank login screen. Journal:
-  `gnome-session-manager@gnome-login.service: Failed with result 'protocol'`,
-  `Failed to fill session`.
-- **Cause:** GDM 50's greeter is now a full `gnome-session` invocation
-  that calls `gsm_session_fill → find_valid_session_keyfile` to locate
-  `gnome-login.session` via `XDG_DATA_DIRS`. nixpkgs adds
-  `${sessionData.desktops}/share` to system-wide `XDG_DATA_DIRS` (so
-  `wayland-sessions/hyprland.desktop` is found) but **not** `${gdm}/share`
-  or `${gnome-session}/share` — so the session keyfile in
-  `gnome-session/sessions/` is unreachable.
-- **Fix:** `modules/desktop/display-manager/default.nix` —
-  ```nix
-  environment.sessionVariables.XDG_DATA_DIRS = [
-    "${pkgs.gdm}/share"
-    "${pkgs.gnome-session}/share"
-  ];
-  ```
-- **Upstream:** no nixpkgs issue filed yet (PR opportunity).
-- **Remove when:** nixpkgs `gdm.nix` adds `${pkgs.gdm}/share` and
-  `${pkgs.gnome-session}/share` to
-  `environment.sessionVariables.XDG_DATA_DIRS` alongside the existing
-  `${sessionData.desktops}/share` entry.
-
----
-
-## `hyprpolkitagent` autostarts in the GDM greeter and ABRTs
-
-- **Symptom:** Hyprpolkit ABRT crash loop inside the gdm-greeter user
-  session (`Failed to create wl_display`); after 5 restarts hits
+- **Symptom:** Hyprpolkit ABRT crash loop inside the greetd `greeter`
+  user session (`Failed to create wl_display`); after 5 restarts hits
   `start-limit-hit`, tears the greeter session down → blank login
   screen.
 - **Cause:** Upstream `hyprpolkitagent.service` ships
   `WantedBy=graphical-session.target`, which fires in **any** graphical
-  user session including GDM's greeter. The greeter has no Hyprland
-  compositor for the agent to attach to.
+  user session including the greetd greeter, where the agent may have no
+  Hyprland wl_display to attach to.
 - **Fix:** `modules/desktop/hyprland/default.nix` —
-  `systemd.user.services.hyprpolkitagent.unitConfig.ConditionGroup = "!gdm";`
+  `systemd.user.services.hyprpolkitagent.unitConfig.ConditionGroup = "!greeter";`
 - **Upstream:** same class of bug as
   [nixpkgs#347651](https://github.com/NixOS/nixpkgs/issues/347651) for
   `hypridle`. Canonical fix proposed in
   [nixpkgs#355416](https://github.com/NixOS/nixpkgs/pull/355416) (uses
   `ConditionEnvironment=XDG_SESSION_DESKTOP=Hyprland`, endorsed by
   fufexan) but unmerged. We use `ConditionGroup` instead because it's
-  UWSM-independent (gdm-greeter and gdm-greeter-{1..4} all share
-  primary group `gdm`; regular users do not).
+  UWSM-independent (the greetd greeter runs as user `greeter`, primary
+  group `greeter`; regular users do not).
+- **Verify:** this guard was repointed from the GDM greeter group to the
+  greetd `greeter` group during the GDM-to-DankGreeter migration. Confirm
+  on the consuming system that hyprpolkitagent does not crash-loop in the
+  greeter session and starts normally in the user session.
 - **Remove when:** the upstream `hyprpolkitagent.service` unit drops
   `WantedBy=graphical-session.target` in favour of a Hyprland-specific
   target, **or** nixpkgs#355416 (or equivalent) merges and ships the

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -13,7 +13,7 @@ says it's safe to remove.
 
 - **Symptom:** none at runtime. This is a security exposure, not a
   visible failure. It applies whenever the DankGreeter is the login
-  manager (`hyprflake.desktop.displayManager.enable`, the default).
+  manager, which on hyprflake is always (the greeter is core, no toggle).
 - **Cause:** the upstream greeter's `greetd` `preStart` runs as root,
   reads the user's `settings.json` / `session.json` (synced via
   `configHome`), then copies the file paths they reference

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -19,9 +19,10 @@ package, or `hyprpolkitagent`.
   reads the user's `settings.json` / `session.json` (synced via
   `configHome`), then copies the file paths they reference
   (`customThemeFile`, `wallpaperPath*`, `monitorWallpapers*`) into
-  `/var/lib/dms-greeter` and runs `chown greeter:` over the result. Any
-  path written into those JSON files is followed by root and the copy is
-  handed to the unprivileged `greeter` user. The `customThemeFile` copy
+  `/var/lib/dms-greeter` and runs `chown greeter:` over the result
+  (assuming the default `greeter` greetd session user, which hyprflake
+  does not override). Any path written into those JSON files is followed
+  by root and the copy is handed to the unprivileged `greeter` user. The `customThemeFile` copy
   is also how Stylix theming reaches the greeter, so it cannot simply be
   dropped without losing the themed login screen.
 - **Impact:** bounded under the single-user threat model. The writer of

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -10,6 +10,35 @@ package, or `hyprpolkitagent`.
 
 ---
 
+## DankGreeter preStart exposes user config paths to the `greeter` user
+
+- **Symptom:** none at runtime. This is a security exposure, not a
+  visible failure, and it only applies when
+  `hyprflake.desktop.displayManager.backend = "dms-greeter"`.
+- **Cause:** the upstream greeter's `greetd` `preStart` runs as root,
+  reads the user's `settings.json` / `session.json` (synced via
+  `configHome`), then copies the file paths they reference
+  (`customThemeFile`, `wallpaperPath*`, `monitorWallpapers*`) into
+  `/var/lib/dms-greeter` and runs `chown greeter:` over the result. Any
+  path written into those JSON files is followed by root and the copy is
+  handed to the unprivileged `greeter` user. The `customThemeFile` copy
+  is also how Stylix theming reaches the greeter, so it cannot simply be
+  dropped without losing the themed login screen.
+- **Impact:** bounded under the single-user threat model. The writer of
+  the DMS config is the primary user, so the realistic risk is something
+  running as that user planting a root-only path (e.g. a key file) and
+  getting a `greeter`-readable copy. Not a remote or cross-user vector.
+- **Fix location:** upstream `distro/nix/greeter.nix` `preStart`. The
+  right fix is upstream validating that the referenced paths resolve
+  under the user's own DMS state dir before copying, and dropping the
+  blanket `chown greeter:`. Not patched hyprflake-side because
+  reimplementing the preStart via `mkForce` is fragile across DMS bumps.
+- **Upstream:** file an issue against `AvengeMedia/DankMaterialShell`.
+- **Remove when:** the upstream greeter sandboxes path resolution in its
+  `preStart`. **Revisit on every DMS input bump.**
+
+---
+
 ## GDM 50 greeter cannot find `gnome-session`
 
 - **Symptom:** post-boot, blank login screen. Journal:

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -12,8 +12,8 @@
     # Imported here, where hyprflakeInputs is a direct argument; importing it
     # from a submodule that receives hyprflakeInputs via _module.args recurses
     # (imports are resolved before config, but _module.args needs config). Its
-    # config is gated by `.greeter.enable`, flipped on only for the dms-greeter
-    # display-manager backend.
+    # config is gated by `.greeter.enable`, flipped on by
+    # hyprflake.desktop.displayManager.enable.
     hyprflakeInputs.dank-material-shell.nixosModules.greeter
 
     # Desktop components

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -12,8 +12,8 @@
     # Imported here, where hyprflakeInputs is a direct argument; importing it
     # from a submodule that receives hyprflakeInputs via _module.args recurses
     # (imports are resolved before config, but _module.args needs config). Its
-    # config is gated by `.greeter.enable`, flipped on by
-    # hyprflake.desktop.displayManager.enable.
+    # config is gated by `.greeter.enable`, which the display-manager module
+    # turns on unconditionally (the login manager is core, not optional).
     hyprflakeInputs.dank-material-shell.nixosModules.greeter
 
     # Desktop components

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -8,6 +8,14 @@
     # Stylix module system (provides stylix.* options)
     hyprflakeInputs.stylix.nixosModules.stylix
 
+    # DankGreeter NixOS module (provides programs.dank-material-shell.greeter.*).
+    # Imported here, where hyprflakeInputs is a direct argument; importing it
+    # from a submodule that receives hyprflakeInputs via _module.args recurses
+    # (imports are resolved before config, but _module.args needs config). Its
+    # config is gated by `.greeter.enable`, flipped on only for the dms-greeter
+    # display-manager backend.
+    hyprflakeInputs.dank-material-shell.nixosModules.greeter
+
     # Desktop components
     ./desktop/autostart
     ./desktop/dank

--- a/modules/desktop/display-manager/default.nix
+++ b/modules/desktop/display-manager/default.nix
@@ -103,6 +103,13 @@ in
         }
       ];
 
+      # Auto-unlock at the greeter rides on the keyring module's greetd PAM
+      # hook. If the keyring module is off, the greeter still works but the
+      # login keyring will not unlock; warn rather than fail so a deliberate
+      # external keyring setup is still allowed.
+      warnings = lib.optional (!config.hyprflake.system.keyring.enable)
+        ''hyprflake.desktop.displayManager.backend = "dms-greeter" with hyprflake.system.keyring disabled: the greeter login will not auto-unlock GNOME Keyring.'';
+
       # greetd-based DankGreeter. The session compositor (Hyprland) and its
       # wayland session are registered at the system level by the hyprland
       # module (programs.hyprland.enable), which the greeter requires.
@@ -116,8 +123,11 @@ in
         # Copy the user's DMS config into the greeter so the login screen
         # inherits the Stylix-driven theme (DMS exports dms-colors.json). The
         # greeter copies these at greetd preStart into /var/lib/dms-greeter,
-        # which is writable state, not the read-only store.
-        configHome = "/home/${config.hyprflake.user.username}";
+        # which is writable state, not the read-only store. Sourced from the
+        # user's declared home so non-standard homes (impermanence, homed,
+        # users.users.<name>.home overrides) still resolve correctly; a hardcoded
+        # /home/<name> would silently miss and leave the greeter unthemed.
+        configHome = config.users.users.${config.hyprflake.user.username}.home;
       };
     })
   ]);

--- a/modules/desktop/display-manager/default.nix
+++ b/modules/desktop/display-manager/default.nix
@@ -2,59 +2,123 @@
 
 let
   cfg = config.hyprflake.desktop.displayManager;
+  kbd = config.hyprflake.desktop.keyboard;
+
+  # The greeter runs its own throwaway Hyprland instance for the login screen.
+  # Inject the keyboard layout so the password field matches the user's layout.
+  # This is hyprlang config for the ephemeral greeter compositor only, consumed
+  # via the greeter's `-C` flag. The project's Lua-only rule applies to the main
+  # session config, not this disposable greeter config.
+  greeterKbConfig = ''
+    input {
+        kb_layout = ${kbd.layout}
+    ${lib.optionalString (kbd.variant != "") "    kb_variant = ${kbd.variant}\n"}}
+  '';
 in
 {
-  options.hyprflake.desktop.displayManager.enable = lib.mkEnableOption "GDM display manager. Note: also propagates keyboard layout from hyprflake.desktop.keyboard" // { default = true; };
+  # The DankGreeter NixOS module (programs.dank-material-shell.greeter.*) is
+  # imported in modules/default.nix, where hyprflakeInputs is a direct argument.
+  # Importing it here would recurse (hyprflakeInputs arrives via _module.args,
+  # which is unavailable during imports resolution). This module only flips the
+  # greeter options in config below.
 
-  config = lib.mkIf cfg.enable {
-    # GDM Display Manager configuration for Hyprland
-    # Provides graphical login with Wayland support
+  options.hyprflake.desktop.displayManager = {
+    enable = lib.mkEnableOption "display manager. Note: also propagates keyboard layout from hyprflake.desktop.keyboard" // { default = true; };
 
-    services = {
-      # GDM with Wayland (GNOME 50+ is Wayland-only; the wayland option was
-      # removed upstream, so we no longer set it explicitly).
-      displayManager = {
-        gdm = {
-          enable = true;
-        };
+    backend = lib.mkOption {
+      type = lib.types.enum [ "gdm" "dms-greeter" ];
+      default = "gdm";
+      description = ''
+        Which display manager to use.
 
-        # Set Hyprland as default session
-        defaultSession =
-          if config.programs.hyprland.withUWSM or false
-          then "hyprland-uwsm"
-          else "hyprland";
-      };
+        - "gdm": GNOME Display Manager (the historical default; carries the
+          GDM 50 / gnome-session workarounds in docs/workarounds.md).
+        - "dms-greeter": DankMaterialShell's greetd-based greeter, themed from
+          the same Stylix-controlled DMS config as the shell.
 
-      # X server configuration for keymap
-      xserver = {
-        enable = true;
-
-        # Configure keymap from hyprflake.desktop options
-        xkb = {
-          inherit (config.hyprflake.desktop.keyboard) layout variant;
-        };
-
-        # Exclude unnecessary X11 packages
-        excludePackages = [ pkgs.xterm ];
-      };
+        Both code paths stay in the tree, so switching back is a one-line flip
+        plus rebuild. The keyring PAM unlock hook (modules/system/keyring)
+        follows this selection.
+      '';
     };
-
-    # GDM 50's greeter Exec=gnome-session, but nixpkgs only adds gnome-session
-    # to the display-manager service PATH — not the gdm-greeter user's PATH.
-    # Without this, the greeter exits with "Unable to run session" and the
-    # login screen is blank. Drop once nixpkgs grows the systemPackages entry.
-    environment.systemPackages = [ pkgs.gnome-session ];
-
-    # GDM 50's greeter session is gnome-session, which calls gsm_session_fill
-    # → find_valid_session_keyfile to locate gnome-login.session. That walks
-    # XDG_DATA_DIRS. nixpkgs adds ${sessionData.desktops}/share to system-wide
-    # XDG_DATA_DIRS but NOT gdm or gnome-session — so the greeter can find
-    # hyprland.desktop (wayland-sessions/) but not gnome-login.session
-    # (gnome-session/sessions/). Result: greeter logs "Failed to fill session"
-    # on every retry and the login screen is blank.
-    environment.sessionVariables.XDG_DATA_DIRS = [
-      "${pkgs.gdm}/share"
-      "${pkgs.gnome-session}/share"
-    ];
   };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    # ----- GDM backend -------------------------------------------------------
+    (lib.mkIf (cfg.backend == "gdm") {
+      services = {
+        # GDM with Wayland (GNOME 50+ is Wayland-only; the wayland option was
+        # removed upstream, so we no longer set it explicitly).
+        displayManager = {
+          gdm.enable = true;
+
+          # Set Hyprland as default session
+          defaultSession =
+            if config.programs.hyprland.withUWSM or false
+            then "hyprland-uwsm"
+            else "hyprland";
+        };
+
+        # X server configuration for keymap (GDM greeter only).
+        xserver = {
+          enable = true;
+
+          xkb = {
+            inherit (kbd) layout variant;
+          };
+
+          excludePackages = [ pkgs.xterm ];
+        };
+      };
+
+      # GDM 50's greeter Exec=gnome-session, but nixpkgs only adds gnome-session
+      # to the display-manager service PATH — not the gdm-greeter user's PATH.
+      # Without this, the greeter exits with "Unable to run session" and the
+      # login screen is blank. Drop once nixpkgs grows the systemPackages entry.
+      environment.systemPackages = [ pkgs.gnome-session ];
+
+      # GDM 50's greeter session is gnome-session, which calls gsm_session_fill
+      # → find_valid_session_keyfile to locate gnome-login.session. That walks
+      # XDG_DATA_DIRS. nixpkgs adds ${sessionData.desktops}/share to system-wide
+      # XDG_DATA_DIRS but NOT gdm or gnome-session — so the greeter can find
+      # hyprland.desktop (wayland-sessions/) but not gnome-login.session
+      # (gnome-session/sessions/). Result: greeter logs "Failed to fill session"
+      # on every retry and the login screen is blank.
+      environment.sessionVariables.XDG_DATA_DIRS = [
+        "${pkgs.gdm}/share"
+        "${pkgs.gnome-session}/share"
+      ];
+    })
+
+    # ----- DankGreeter (dms-greeter) backend ---------------------------------
+    (lib.mkIf (cfg.backend == "dms-greeter") {
+      assertions = [
+        {
+          assertion = config.hyprflake.user.username != null;
+          message = ''
+            hyprflake.desktop.displayManager.backend = "dms-greeter" needs
+            hyprflake.user.username set so the greeter can sync the user's DMS
+            config (configHome). Set hyprflake.user.username = "<you>".
+          '';
+        }
+      ];
+
+      # greetd-based DankGreeter. The session compositor (Hyprland) and its
+      # wayland session are registered at the system level by the hyprland
+      # module (programs.hyprland.enable), which the greeter requires.
+      programs.dank-material-shell.greeter = {
+        enable = true;
+        compositor.name = "hyprland";
+
+        # Inject the user's keyboard layout into the greeter's login compositor.
+        compositor.customConfig = greeterKbConfig;
+
+        # Copy the user's DMS config into the greeter so the login screen
+        # inherits the Stylix-driven theme (DMS exports dms-colors.json). The
+        # greeter copies these at greetd preStart into /var/lib/dms-greeter,
+        # which is writable state, not the read-only store.
+        configHome = "/home/${config.hyprflake.user.username}";
+      };
+    })
+  ]);
 }

--- a/modules/desktop/display-manager/default.nix
+++ b/modules/desktop/display-manager/default.nix
@@ -1,8 +1,9 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 
 let
   cfg = config.hyprflake.desktop.displayManager;
   kbd = config.hyprflake.desktop.keyboard;
+  username = config.hyprflake.user.username;
 
   # The greeter runs its own throwaway Hyprland instance for the login screen.
   # Inject the keyboard layout so the password field matches the user's layout.
@@ -20,135 +21,74 @@ let
   '';
 in
 {
+  # hyprflake's login manager is DankMaterialShell's greetd-based greeter. GDM
+  # was removed in favour of it (DMS-first): the login screen and the shell now
+  # share one Stylix-driven theme, and the GDM 50 / gnome-session workaround
+  # stack is gone. Rollback is the backup/pre-dank-baseline branch or a previous
+  # NixOS generation, not an in-tree toggle.
+  #
   # The DankGreeter NixOS module (programs.dank-material-shell.greeter.*) is
   # imported in modules/default.nix, where hyprflakeInputs is a direct argument.
   # Importing it here would recurse (hyprflakeInputs arrives via _module.args,
-  # which is unavailable during imports resolution). This module only flips the
-  # greeter options in config below.
+  # which is unavailable during imports resolution). This module configures the
+  # greeter in config below.
 
-  options.hyprflake.desktop.displayManager = {
-    enable = lib.mkEnableOption "display manager. Note: also propagates keyboard layout from hyprflake.desktop.keyboard" // { default = true; };
+  options.hyprflake.desktop.displayManager.enable =
+    lib.mkEnableOption "the DankGreeter (greetd) login manager; also propagates keyboard layout from hyprflake.desktop.keyboard to the greeter" // { default = true; };
 
-    backend = lib.mkOption {
-      type = lib.types.enum [ "gdm" "dms-greeter" ];
-      default = "gdm";
-      description = ''
-        Which display manager to use.
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = username != null;
+        message = ''
+          hyprflake.desktop.displayManager is enabled but
+          hyprflake.user.username is unset. The DankGreeter needs it to sync the
+          user's DMS config to the login screen (configHome). Set
+          hyprflake.user.username = "<you>", or set displayManager.enable = false
+          to run your own login manager.
+        '';
+      }
+      {
+        # configHome reads users.users.<name>.home (an attrset the consumer
+        # owns; the hyprflake.user module only declares the option). Guard the
+        # lookup so an undeclared/typo'd username fails with guidance instead of
+        # a bare "attribute '<name>' missing".
+        assertion = username == null || builtins.hasAttr username config.users.users;
+        message = ''
+          hyprflake.desktop.displayManager reads the home of
+          hyprflake.user.username (${toString username}) from users.users, but
+          that user is not declared. Declare users.users.${toString username}
+          (the primary user) so the greeter can resolve its home directory.
+        '';
+      }
+    ];
 
-        - "gdm": GNOME Display Manager (the historical default; carries the
-          GDM 50 / gnome-session workarounds in docs/workarounds.md).
-        - "dms-greeter": DankMaterialShell's greetd-based greeter, themed from
-          the same Stylix-controlled DMS config as the shell.
+    # Auto-unlock at the greeter rides on the keyring module's greetd PAM hook.
+    # If the keyring module is off, the greeter still works but the login keyring
+    # will not unlock; warn rather than fail so a deliberate external keyring
+    # setup is still allowed.
+    warnings = lib.optional (!config.hyprflake.system.keyring.enable)
+      ''hyprflake.desktop.displayManager is enabled with hyprflake.system.keyring disabled: the greeter login will not auto-unlock GNOME Keyring.'';
 
-        Both code paths stay in the tree, so switching back is a one-line flip
-        plus rebuild. The keyring PAM unlock hook (modules/system/keyring)
-        follows this selection.
-      '';
+    # greetd-based DankGreeter. The session compositor (Hyprland) and its wayland
+    # session are registered at the system level by the hyprland module
+    # (programs.hyprland.enable), which the greeter requires.
+    programs.dank-material-shell.greeter = {
+      enable = true;
+      compositor.name = "hyprland";
+
+      # Inject the user's keyboard layout into the greeter's login compositor.
+      compositor.customConfig = greeterKbConfig;
+
+      # Copy the user's DMS config into the greeter so the login screen inherits
+      # the Stylix-driven theme (DMS exports dms-colors.json). The greeter copies
+      # these at greetd preStart into /var/lib/dms-greeter, which is writable
+      # state, not the read-only store. Sourced from the user's declared home so
+      # non-standard homes (impermanence, homed, users.users.<name>.home
+      # overrides) still resolve correctly; a hardcoded /home/<name> would
+      # silently miss and leave the greeter unthemed. Guarded on username so a
+      # null value fails via the assertion above, not a string-coercion error.
+      configHome = lib.mkIf (username != null) config.users.users.${username}.home;
     };
   };
-
-  config = lib.mkIf cfg.enable (lib.mkMerge [
-    # ----- GDM backend -------------------------------------------------------
-    (lib.mkIf (cfg.backend == "gdm") {
-      services = {
-        # GDM with Wayland (GNOME 50+ is Wayland-only; the wayland option was
-        # removed upstream, so we no longer set it explicitly).
-        displayManager = {
-          gdm.enable = true;
-
-          # Set Hyprland as default session
-          defaultSession =
-            if config.programs.hyprland.withUWSM or false
-            then "hyprland-uwsm"
-            else "hyprland";
-        };
-
-        # X server configuration for keymap (GDM greeter only).
-        xserver = {
-          enable = true;
-
-          xkb = {
-            inherit (kbd) layout variant;
-          };
-
-          excludePackages = [ pkgs.xterm ];
-        };
-      };
-
-      # GDM 50's greeter Exec=gnome-session, but nixpkgs only adds gnome-session
-      # to the display-manager service PATH — not the gdm-greeter user's PATH.
-      # Without this, the greeter exits with "Unable to run session" and the
-      # login screen is blank. Drop once nixpkgs grows the systemPackages entry.
-      environment.systemPackages = [ pkgs.gnome-session ];
-
-      # GDM 50's greeter session is gnome-session, which calls gsm_session_fill
-      # → find_valid_session_keyfile to locate gnome-login.session. That walks
-      # XDG_DATA_DIRS. nixpkgs adds ${sessionData.desktops}/share to system-wide
-      # XDG_DATA_DIRS but NOT gdm or gnome-session — so the greeter can find
-      # hyprland.desktop (wayland-sessions/) but not gnome-login.session
-      # (gnome-session/sessions/). Result: greeter logs "Failed to fill session"
-      # on every retry and the login screen is blank.
-      environment.sessionVariables.XDG_DATA_DIRS = [
-        "${pkgs.gdm}/share"
-        "${pkgs.gnome-session}/share"
-      ];
-    })
-
-    # ----- DankGreeter (dms-greeter) backend ---------------------------------
-    (lib.mkIf (cfg.backend == "dms-greeter") {
-      assertions = [
-        {
-          assertion = config.hyprflake.user.username != null;
-          message = ''
-            hyprflake.desktop.displayManager.backend = "dms-greeter" needs
-            hyprflake.user.username set so the greeter can sync the user's DMS
-            config (configHome). Set hyprflake.user.username = "<you>".
-          '';
-        }
-        {
-          # configHome reads users.users.<name>.home (an attrset the consumer
-          # owns; the hyprflake.user module only declares the option). Guard the
-          # lookup so an undeclared/typo'd username fails with guidance instead
-          # of a bare "attribute '<name>' missing".
-          assertion =
-            config.hyprflake.user.username == null
-            || builtins.hasAttr config.hyprflake.user.username config.users.users;
-          message = ''
-            hyprflake.desktop.displayManager.backend = "dms-greeter" reads the
-            home of hyprflake.user.username (${toString config.hyprflake.user.username})
-            from users.users, but that user is not declared. Declare
-            users.users.${toString config.hyprflake.user.username} (the primary
-            user) so the greeter can resolve its home directory.
-          '';
-        }
-      ];
-
-      # Auto-unlock at the greeter rides on the keyring module's greetd PAM
-      # hook. If the keyring module is off, the greeter still works but the
-      # login keyring will not unlock; warn rather than fail so a deliberate
-      # external keyring setup is still allowed.
-      warnings = lib.optional (!config.hyprflake.system.keyring.enable)
-        ''hyprflake.desktop.displayManager.backend = "dms-greeter" with hyprflake.system.keyring disabled: the greeter login will not auto-unlock GNOME Keyring.'';
-
-      # greetd-based DankGreeter. The session compositor (Hyprland) and its
-      # wayland session are registered at the system level by the hyprland
-      # module (programs.hyprland.enable), which the greeter requires.
-      programs.dank-material-shell.greeter = {
-        enable = true;
-        compositor.name = "hyprland";
-
-        # Inject the user's keyboard layout into the greeter's login compositor.
-        compositor.customConfig = greeterKbConfig;
-
-        # Copy the user's DMS config into the greeter so the login screen
-        # inherits the Stylix-driven theme (DMS exports dms-colors.json). The
-        # greeter copies these at greetd preStart into /var/lib/dms-greeter,
-        # which is writable state, not the read-only store. Sourced from the
-        # user's declared home so non-standard homes (impermanence, homed,
-        # users.users.<name>.home overrides) still resolve correctly; a hardcoded
-        # /home/<name> would silently miss and leave the greeter unthemed.
-        configHome = config.users.users.${config.hyprflake.user.username}.home;
-      };
-    })
-  ]);
 }

--- a/modules/desktop/display-manager/default.nix
+++ b/modules/desktop/display-manager/default.nix
@@ -66,6 +66,24 @@ in
   ];
 
   config = {
+    # kbd.layout/variant are interpolated verbatim into the greeter's hyprlang
+    # compositor config (greeterKbConfig). They are build-time NixOS options set
+    # by the system builder, not runtime user input, so this is defence in depth
+    # rather than a live attacker path: constrain them to xkb tokens (letters,
+    # digits, comma for multi-layout, underscore, hyphen) so a stray newline or
+    # brace can never inject a compositor directive even if these options later
+    # move to a less-trusted source.
+    assertions = [
+      {
+        assertion = builtins.match "[a-zA-Z0-9,_-]*" kbd.layout != null;
+        message = "hyprflake.desktop.keyboard.layout must be xkb tokens ([a-zA-Z0-9,_-]); got ${builtins.toJSON kbd.layout}.";
+      }
+      {
+        assertion = builtins.match "[a-zA-Z0-9,_-]*" kbd.variant != null;
+        message = "hyprflake.desktop.keyboard.variant must be xkb tokens ([a-zA-Z0-9,_-]) or empty; got ${builtins.toJSON kbd.variant}.";
+      }
+    ];
+
     # Auto-unlock at the greeter rides on the keyring module's greetd PAM hook.
     # If the keyring module is off, the greeter still works but the login keyring
     # will not unlock; warn rather than fail so a deliberate external keyring

--- a/modules/desktop/display-manager/default.nix
+++ b/modules/desktop/display-manager/default.nix
@@ -101,6 +101,22 @@ in
             config (configHome). Set hyprflake.user.username = "<you>".
           '';
         }
+        {
+          # configHome reads users.users.<name>.home (an attrset the consumer
+          # owns; the hyprflake.user module only declares the option). Guard the
+          # lookup so an undeclared/typo'd username fails with guidance instead
+          # of a bare "attribute '<name>' missing".
+          assertion =
+            config.hyprflake.user.username == null
+            || builtins.hasAttr config.hyprflake.user.username config.users.users;
+          message = ''
+            hyprflake.desktop.displayManager.backend = "dms-greeter" reads the
+            home of hyprflake.user.username (${toString config.hyprflake.user.username})
+            from users.users, but that user is not declared. Declare
+            users.users.${toString config.hyprflake.user.username} (the primary
+            user) so the greeter can resolve its home directory.
+          '';
+        }
       ];
 
       # Auto-unlock at the greeter rides on the keyring module's greetd PAM

--- a/modules/desktop/display-manager/default.nix
+++ b/modules/desktop/display-manager/default.nix
@@ -1,9 +1,17 @@
 { config, lib, ... }:
 
 let
-  cfg = config.hyprflake.desktop.displayManager;
   kbd = config.hyprflake.desktop.keyboard;
   username = config.hyprflake.user.username;
+
+  # The greeter copies the primary user's DMS config (theme, wallpaper) and
+  # resolves their avatar from users.users.<name>.home. Both need a username
+  # that is actually declared as a system user. Resolve that once; when it does
+  # not hold the greeter still logs in, just with the default theme and no
+  # avatar, so this degrades to a warning rather than a build failure.
+  # The `username != null` disjunct is load-bearing: builtins.hasAttr throws on
+  # a null name, so it has to short-circuit before the lookup.
+  userDeclared = username != null && builtins.hasAttr username config.users.users;
 
   # The greeter runs its own throwaway Hyprland instance for the login screen.
   # Inject the keyboard layout so the password field matches the user's layout.
@@ -27,51 +35,30 @@ in
   # stack is gone. Rollback is the backup/pre-dank-baseline branch or a previous
   # NixOS generation, not an in-tree toggle.
   #
+  # There is no enable option. A login manager is core infrastructure (like the
+  # DMS shell itself): always needed, always present. A toggle would only be
+  # warranted if hyprflake supported more than one. To run a different login
+  # manager, override services.greetd / programs.dank-material-shell.greeter
+  # directly, the way any other always-on component is replaced.
+  #
   # The DankGreeter NixOS module (programs.dank-material-shell.greeter.*) is
   # imported in modules/default.nix, where hyprflakeInputs is a direct argument.
   # Importing it here would recurse (hyprflakeInputs arrives via _module.args,
   # which is unavailable during imports resolution). This module configures the
   # greeter in config below.
 
-  options.hyprflake.desktop.displayManager.enable =
-    lib.mkEnableOption "the DankGreeter (greetd) login manager; also propagates keyboard layout from hyprflake.desktop.keyboard to the greeter" // { default = true; };
-
-  config = lib.mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = username != null;
-        message = ''
-          hyprflake.desktop.displayManager is enabled but
-          hyprflake.user.username is unset. The DankGreeter needs it to sync the
-          user's DMS config to the login screen (configHome). Set
-          hyprflake.user.username = "<you>", or set displayManager.enable = false
-          to run your own login manager.
-        '';
-      }
-      {
-        # configHome reads users.users.<name>.home (an attrset the consumer
-        # owns; the hyprflake.user module only declares the option). Guard the
-        # lookup so an undeclared/typo'd username fails with guidance instead of
-        # a bare "attribute '<name>' missing". The `username == null` disjunct is
-        # load-bearing: assertions are evaluated together, and builtins.hasAttr
-        # throws on a null name, so without the short-circuit a null username
-        # would crash here instead of failing the assertion above.
-        assertion = username == null || builtins.hasAttr username config.users.users;
-        message = ''
-          hyprflake.desktop.displayManager reads the home of
-          hyprflake.user.username (${toString username}) from users.users, but
-          that user is not declared. Declare users.users.${toString username}
-          (the primary user) so the greeter can resolve its home directory.
-        '';
-      }
-    ];
-
+  config = {
     # Auto-unlock at the greeter rides on the keyring module's greetd PAM hook.
     # If the keyring module is off, the greeter still works but the login keyring
     # will not unlock; warn rather than fail so a deliberate external keyring
-    # setup is still allowed.
-    warnings = lib.optional (!config.hyprflake.system.keyring.enable)
-      ''hyprflake.desktop.displayManager is enabled with hyprflake.system.keyring disabled: the greeter login will not auto-unlock GNOME Keyring.'';
+    # setup is still allowed. A second warning covers the theming/avatar path:
+    # without a declared primary user the greeter cannot find that user's DMS
+    # config or face icon, so it falls back to the default look.
+    warnings =
+      (lib.optional (!config.hyprflake.system.keyring.enable)
+        ''hyprflake.system.keyring is disabled: the DankGreeter login will not auto-unlock GNOME Keyring.'')
+      ++ (lib.optional (!userDeclared)
+        ''hyprflake.user.username is unset or names a user not declared in users.users; the DankGreeter login screen will use the default theme and no avatar instead of the primary user's Stylix DMS theme and photo. Set hyprflake.user.username to your declared primary user to theme the greeter.'');
 
     # greetd-based DankGreeter. The session compositor (Hyprland) and its wayland
     # session are registered at the system level by the hyprland module
@@ -89,9 +76,10 @@ in
       # state, not the read-only store. Sourced from the user's declared home so
       # non-standard homes (impermanence, homed, users.users.<name>.home
       # overrides) still resolve correctly; a hardcoded /home/<name> would
-      # silently miss and leave the greeter unthemed. Guarded on username so a
-      # null value fails via the assertion above, not a string-coercion error.
-      configHome = lib.mkIf (username != null) config.users.users.${username}.home;
+      # silently miss and leave the greeter unthemed. Guarded on a declared user
+      # so a null or typo'd username degrades to the default theme (and the
+      # warning above) instead of a string-coercion or missing-attr eval error.
+      configHome = lib.mkIf userDeclared config.users.users.${username}.home;
     };
   };
 }

--- a/modules/desktop/display-manager/default.nix
+++ b/modules/desktop/display-manager/default.nix
@@ -47,6 +47,24 @@ in
   # which is unavailable during imports resolution). This module configures the
   # greeter in config below.
 
+  imports = [
+    # The greeter used to live behind hyprflake.desktop.displayManager.enable.
+    # That option is gone (the login manager is core, always-on), so give
+    # consumers a clear eval error instead of the bare "option does not exist".
+    # mkRemovedOptionModule throws whenever the option is still set, with either
+    # value: `= true` was a no-op (already the behaviour), and `= false` asked
+    # for no DM, which can no longer be honoured, so both should fail loudly and
+    # point at the fix.
+    (lib.mkRemovedOptionModule [ "hyprflake" "desktop" "displayManager" "enable" ] ''
+      hyprflake.desktop.displayManager.enable has been removed. The DankGreeter
+      (greetd) login manager is now core infrastructure, always enabled, like the
+      DankMaterialShell shell itself. Drop this option from your configuration. To
+      run a different login manager, override services.greetd or
+      programs.dank-material-shell.greeter directly. To roll back to GDM, use the
+      backup/pre-dank-baseline branch or boot a previous NixOS generation.
+    '')
+  ];
+
   config = {
     # Auto-unlock at the greeter rides on the keyring module's greetd PAM hook.
     # If the keyring module is off, the greeter still works but the login keyring
@@ -56,7 +74,7 @@ in
     # config or face icon, so it falls back to the default look.
     warnings =
       (lib.optional (!config.hyprflake.system.keyring.enable)
-        ''hyprflake.system.keyring is disabled: the DankGreeter login will not auto-unlock GNOME Keyring.'')
+        ''hyprflake.system.keyring is disabled, so the DankGreeter login will not auto-unlock GNOME Keyring through the greetd PAM hook. If you manage a keyring elsewhere this is expected; otherwise enable hyprflake.system.keyring.'')
       ++ (lib.optional (!userDeclared)
         ''hyprflake.user.username is unset or names a user not declared in users.users; the DankGreeter login screen will use the default theme and no avatar instead of the primary user's Stylix DMS theme and photo. Set hyprflake.user.username to your declared primary user to theme the greeter.'');
 

--- a/modules/desktop/display-manager/default.nix
+++ b/modules/desktop/display-manager/default.nix
@@ -52,7 +52,10 @@ in
         # configHome reads users.users.<name>.home (an attrset the consumer
         # owns; the hyprflake.user module only declares the option). Guard the
         # lookup so an undeclared/typo'd username fails with guidance instead of
-        # a bare "attribute '<name>' missing".
+        # a bare "attribute '<name>' missing". The `username == null` disjunct is
+        # load-bearing: assertions are evaluated together, and builtins.hasAttr
+        # throws on a null name, so without the short-circuit a null username
+        # would crash here instead of failing the assertion above.
         assertion = username == null || builtins.hasAttr username config.users.users;
         message = ''
           hyprflake.desktop.displayManager reads the home of

--- a/modules/desktop/display-manager/default.nix
+++ b/modules/desktop/display-manager/default.nix
@@ -9,6 +9,10 @@ let
   # This is hyprlang config for the ephemeral greeter compositor only, consumed
   # via the greeter's `-C` flag. The project's Lua-only rule applies to the main
   # session config, not this disposable greeter config.
+  #
+  # kbd.layout/variant are emitted verbatim into this config. They are
+  # build-time NixOS option strings set by the system builder (not runtime
+  # user input), so this crosses no privilege boundary; keep them to xkb tokens.
   greeterKbConfig = ''
     input {
         kb_layout = ${kbd.layout}

--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -237,14 +237,14 @@ in
     };
 
     # hyprpolkitagent ships WantedBy=graphical-session.target, so it auto-starts
-    # for every Wayland session — including GDM's greeter. It then tries to
-    # bind to the Hyprland wl_display, fails, and ABRTs in a restart loop that
-    # tears the greeter down (blank login screen). Same class of bug as
+    # for every Wayland session — including the greetd greeter session. It then
+    # tries to bind to the Hyprland wl_display, can fail, and ABRTs in a restart
+    # loop that tears the greeter down (blank login screen). Same class of bug as
     # nixpkgs#347651 for hypridle; canonical fix is still unmerged
-    # (nixpkgs#355416). Gate on the gdm group rather than XDG_SESSION_DESKTOP
-    # so it works without UWSM — gdm-greeter and gdm-greeter-{1..4} all share
-    # primary group gdm, real users do not.
-    systemd.user.services.hyprpolkitagent.unitConfig.ConditionGroup = "!gdm";
+    # (nixpkgs#355416). Gate on the greetd `greeter` group rather than
+    # XDG_SESSION_DESKTOP so it works without UWSM — the greetd greeter runs as
+    # user `greeter` (primary group `greeter`), real users do not.
+    systemd.user.services.hyprpolkitagent.unitConfig.ConditionGroup = "!greeter";
 
     # Nautilus enhancements
     # Enable HEIC image thumbnails

--- a/modules/system/keyring/default.nix
+++ b/modules/system/keyring/default.nix
@@ -15,19 +15,24 @@ in
     # The login manager is hyprflake's core DankGreeter on greetd, which
     # authenticates through the `greetd` PAM service, so the login-time
     # auto-unlock hook (pam_gnome_keyring in greetd's auth + session stacks)
-    # lives there. The greeter is always present (no toggle), so this is
-    # unconditional.
-    # `login.enableGnomeKeyring` also stays: the DankMaterialShell lock screen
-    # authenticates against /etc/pam.d/login on NixOS (DMS only uses a dedicated
-    # `dankshell` PAM service if you declare one), so it is what re-unlocks the
-    # keyring when you dismiss the DMS lock.
+    # lives there. It is gated on services.greetd.enable rather than set
+    # unconditionally: hyprflake always runs greetd, but this keyring module has
+    # its own enable toggle and could be used alongside an overridden
+    # services.greetd.enable = false, and the hook should track the service it is
+    # for instead of writing PAM config for a service that is not running.
+    # `login.enableGnomeKeyring` stays unconditional: the DankMaterialShell lock
+    # screen authenticates against /etc/pam.d/login on NixOS (DMS only uses a
+    # dedicated `dankshell` PAM service if you declare one), so it is what
+    # re-unlocks the keyring when you dismiss the DMS lock.
     #
     # Auto-unlock without a second prompt requires the login password to equal
     # the login-keyring password.
-    security.pam.services = {
-      login.enableGnomeKeyring = true;
-      greetd.enableGnomeKeyring = true;
-    };
+    security.pam.services = lib.mkMerge [
+      { login.enableGnomeKeyring = true; }
+      (lib.mkIf config.services.greetd.enable {
+        greetd.enableGnomeKeyring = true;
+      })
+    ];
 
     # GPG agent with graphical pinentry
     # Enables GPG operations (signing, encryption) with GUI password prompts

--- a/modules/system/keyring/default.nix
+++ b/modules/system/keyring/default.nix
@@ -12,15 +12,30 @@ in
     # Based on nixcfg production configuration
 
     # Enable PAM keyring for automatic unlock on login and screen unlock.
-    # GDM unlocks it at login; the DankMaterialShell lock screen authenticates
-    # against /etc/pam.d/login on NixOS (DMS only uses a dedicated `dankshell`
-    # PAM service if you declare one), so `login.enableGnomeKeyring` is what
+    # The login-time auto-unlock rides on whichever PAM service the active
+    # display-manager backend authenticates through:
+    #   - gdm backend: pam_gnome_keyring on `gdm` / `gdm-password`.
+    #   - dms-greeter backend: greetd authenticates via its own PAM service, so
+    #     the hook moves to `greetd`.
+    # `login.enableGnomeKeyring` stays in both cases: the DankMaterialShell lock
+    # screen authenticates against /etc/pam.d/login on NixOS (DMS only uses a
+    # dedicated `dankshell` PAM service if you declare one), so it is what
     # re-unlocks the keyring when you dismiss the DMS lock.
-    security.pam.services = {
-      gdm.enableGnomeKeyring = true;
-      gdm-password.enableGnomeKeyring = true;
-      login.enableGnomeKeyring = true;
-    };
+    #
+    # Auto-unlock without a second prompt requires the login password to equal
+    # the login-keyring password.
+    security.pam.services = lib.mkMerge [
+      {
+        login.enableGnomeKeyring = true;
+      }
+      (lib.mkIf (config.hyprflake.desktop.displayManager.backend == "gdm") {
+        gdm.enableGnomeKeyring = true;
+        gdm-password.enableGnomeKeyring = true;
+      })
+      (lib.mkIf (config.hyprflake.desktop.displayManager.backend == "dms-greeter") {
+        greetd.enableGnomeKeyring = true;
+      })
+    ];
 
     # GPG agent with graphical pinentry
     # Enables GPG operations (signing, encryption) with GUI password prompts
@@ -35,16 +50,16 @@ in
     # - Security wrapper for gnome-keyring-daemon with cap_ipc_lock capability
     # - D-Bus activation for org.freedesktop.secrets
     # - XDG portal integration
-    # - Proper daemon management in user session (survives GDM greeter session transition)
+    # - Proper daemon management in user session (survives the greeter -> user session transition)
     # PAM (configured above) still handles automatic unlock with login password
     services.gnome.gnome-keyring.enable = true;
 
     # Systemd user services for GNOME Keyring
     systemd.user.services = {
       # NOTE: services.gnome.gnome-keyring.enable ensures the daemon runs in the user session
-      # and survives GDM greeter session transitions. PAM (configured above) handles automatic
-      # unlocking with the login password. The daemon can be started by either PAM or D-Bus
-      # activation, and will persist for the entire user session.
+      # and survives the greeter -> user session transition (GDM or greetd). PAM (configured
+      # above) handles automatic unlocking with the login password. The daemon can be started
+      # by either PAM or D-Bus activation, and will persist for the entire user session.
 
       # Polkit authentication agent - required for password prompts and credential dialogs
       # Without this, SSH passphrase prompts cannot display properly

--- a/modules/system/keyring/default.nix
+++ b/modules/system/keyring/default.nix
@@ -24,18 +24,26 @@ in
     #
     # Auto-unlock without a second prompt requires the login password to equal
     # the login-keyring password.
-    security.pam.services = lib.mkMerge [
-      {
-        login.enableGnomeKeyring = true;
-      }
-      (lib.mkIf (config.hyprflake.desktop.displayManager.backend == "gdm") {
-        gdm.enableGnomeKeyring = true;
-        gdm-password.enableGnomeKeyring = true;
-      })
-      (lib.mkIf (config.hyprflake.desktop.displayManager.backend == "dms-greeter") {
-        greetd.enableGnomeKeyring = true;
-      })
-    ];
+    security.pam.services =
+      let
+        dm = config.hyprflake.desktop.displayManager;
+        # Only attach the display-manager unlock hook when this flake actually
+        # owns the display manager. With dm.enable = false the user runs their
+        # own DM, so neither gdm nor greetd here is the login path.
+        owns = dm.enable;
+      in
+      lib.mkMerge [
+        {
+          login.enableGnomeKeyring = true;
+        }
+        (lib.mkIf (owns && dm.backend == "gdm") {
+          gdm.enableGnomeKeyring = true;
+          gdm-password.enableGnomeKeyring = true;
+        })
+        (lib.mkIf (owns && dm.backend == "dms-greeter") {
+          greetd.enableGnomeKeyring = true;
+        })
+      ];
 
     # GPG agent with graphical pinentry
     # Enables GPG operations (signing, encryption) with GUI password prompts

--- a/modules/system/keyring/default.nix
+++ b/modules/system/keyring/default.nix
@@ -12,38 +12,26 @@ in
     # Based on nixcfg production configuration
 
     # Enable PAM keyring for automatic unlock on login and screen unlock.
-    # The login-time auto-unlock rides on whichever PAM service the active
-    # display-manager backend authenticates through:
-    #   - gdm backend: pam_gnome_keyring on `gdm` / `gdm-password`.
-    #   - dms-greeter backend: greetd authenticates via its own PAM service, so
-    #     the hook moves to `greetd`.
-    # `login.enableGnomeKeyring` stays in both cases: the DankMaterialShell lock
+    # The login manager is the DankGreeter on greetd, which authenticates
+    # through the `greetd` PAM service, so the login-time auto-unlock hook lives
+    # there. It is attached only when this flake owns the display manager
+    # (displayManager.enable); with it off the user runs their own login manager
+    # and greetd here is not the login path.
+    # `login.enableGnomeKeyring` stays unconditional: the DankMaterialShell lock
     # screen authenticates against /etc/pam.d/login on NixOS (DMS only uses a
     # dedicated `dankshell` PAM service if you declare one), so it is what
     # re-unlocks the keyring when you dismiss the DMS lock.
     #
     # Auto-unlock without a second prompt requires the login password to equal
     # the login-keyring password.
-    security.pam.services =
-      let
-        dm = config.hyprflake.desktop.displayManager;
-        # Only attach the display-manager unlock hook when this flake actually
-        # owns the display manager. With dm.enable = false the user runs their
-        # own DM, so neither gdm nor greetd here is the login path.
-        owns = dm.enable;
-      in
-      lib.mkMerge [
-        {
-          login.enableGnomeKeyring = true;
-        }
-        (lib.mkIf (owns && dm.backend == "gdm") {
-          gdm.enableGnomeKeyring = true;
-          gdm-password.enableGnomeKeyring = true;
-        })
-        (lib.mkIf (owns && dm.backend == "dms-greeter") {
-          greetd.enableGnomeKeyring = true;
-        })
-      ];
+    security.pam.services = lib.mkMerge [
+      {
+        login.enableGnomeKeyring = true;
+      }
+      (lib.mkIf config.hyprflake.desktop.displayManager.enable {
+        greetd.enableGnomeKeyring = true;
+      })
+    ];
 
     # GPG agent with graphical pinentry
     # Enables GPG operations (signing, encryption) with GUI password prompts
@@ -65,7 +53,7 @@ in
     # Systemd user services for GNOME Keyring
     systemd.user.services = {
       # NOTE: services.gnome.gnome-keyring.enable ensures the daemon runs in the user session
-      # and survives the greeter -> user session transition (GDM or greetd). PAM (configured
+      # and survives the greetd greeter -> user session transition. PAM (configured
       # above) handles automatic unlocking with the login password. The daemon can be started
       # by either PAM or D-Bus activation, and will persist for the entire user session.
 

--- a/modules/system/keyring/default.nix
+++ b/modules/system/keyring/default.nix
@@ -12,26 +12,22 @@ in
     # Based on nixcfg production configuration
 
     # Enable PAM keyring for automatic unlock on login and screen unlock.
-    # The login manager is the DankGreeter on greetd, which authenticates
-    # through the `greetd` PAM service, so the login-time auto-unlock hook lives
-    # there. It is attached only when this flake owns the display manager
-    # (displayManager.enable); with it off the user runs their own login manager
-    # and greetd here is not the login path.
-    # `login.enableGnomeKeyring` stays unconditional: the DankMaterialShell lock
-    # screen authenticates against /etc/pam.d/login on NixOS (DMS only uses a
-    # dedicated `dankshell` PAM service if you declare one), so it is what
-    # re-unlocks the keyring when you dismiss the DMS lock.
+    # The login manager is hyprflake's core DankGreeter on greetd, which
+    # authenticates through the `greetd` PAM service, so the login-time
+    # auto-unlock hook (pam_gnome_keyring in greetd's auth + session stacks)
+    # lives there. The greeter is always present (no toggle), so this is
+    # unconditional.
+    # `login.enableGnomeKeyring` also stays: the DankMaterialShell lock screen
+    # authenticates against /etc/pam.d/login on NixOS (DMS only uses a dedicated
+    # `dankshell` PAM service if you declare one), so it is what re-unlocks the
+    # keyring when you dismiss the DMS lock.
     #
     # Auto-unlock without a second prompt requires the login password to equal
     # the login-keyring password.
-    security.pam.services = lib.mkMerge [
-      {
-        login.enableGnomeKeyring = true;
-      }
-      (lib.mkIf config.hyprflake.desktop.displayManager.enable {
-        greetd.enableGnomeKeyring = true;
-      })
-    ];
+    security.pam.services = {
+      login.enableGnomeKeyring = true;
+      greetd.enableGnomeKeyring = true;
+    };
 
     # GPG agent with graphical pinentry
     # Enables GPG operations (signing, encryption) with GUI password prompts

--- a/modules/system/user/default.nix
+++ b/modules/system/user/default.nix
@@ -36,21 +36,31 @@
   };
 
   config = lib.mkIf (config.hyprflake.user.username != null && config.hyprflake.user.photo != null) {
-    system.activationScripts.hyprflake-user-photo = {
-      text = ''
-                # Create AccountsService directories
-                mkdir -p /var/lib/AccountsService/icons
-                mkdir -p /var/lib/AccountsService/users
+    system.activationScripts.hyprflake-user-photo =
+      let
+        # username and photo are build-time NixOS options (no runtime attacker
+        # path), but they are interpolated into a root activation script, so
+        # quote every expansion with escapeShellArg: a name or path with shell
+        # metacharacters then lands as a literal filename, never as code run by
+        # root at activation. The icon path is the same file the DankGreeter
+        # probes per user, so this script feeds the login avatar.
+        iconPath = "/var/lib/AccountsService/icons/" + config.hyprflake.user.username;
+        userPath = "/var/lib/AccountsService/users/" + config.hyprflake.user.username;
+      in
+      {
+        text = ''
+          # Create AccountsService directories
+          mkdir -p /var/lib/AccountsService/icons
+          mkdir -p /var/lib/AccountsService/users
 
-                # Copy user photo to AccountsService icons directory
-                cp ${config.hyprflake.user.photo} /var/lib/AccountsService/icons/${config.hyprflake.user.username}
+          # Copy user photo to AccountsService icons directory
+          cp ${lib.escapeShellArg (toString config.hyprflake.user.photo)} ${lib.escapeShellArg iconPath}
 
-                # Create AccountsService user configuration
-                cat > /var/lib/AccountsService/users/${config.hyprflake.user.username} << 'EOF'
-        [User]
-        Icon=/var/lib/AccountsService/icons/${config.hyprflake.user.username}
-        EOF
-      '';
-    };
+          # Create AccountsService user configuration. The Icon path is written
+          # as a literal line (printf with a quoted format), so the icon path is
+          # not re-expanded by the shell.
+          printf '[User]\nIcon=%s\n' ${lib.escapeShellArg iconPath} > ${lib.escapeShellArg userPath}
+        '';
+      };
   };
 }

--- a/modules/system/user/default.nix
+++ b/modules/system/user/default.nix
@@ -2,7 +2,7 @@
 
 {
   # User profile configuration
-  # Sets up AccountsService user photo for display managers (GDM, etc.)
+  # Sets up AccountsService user photo for the login greeter (DankGreeter)
 
   options.hyprflake.user = {
     username = lib.mkOption {
@@ -24,7 +24,7 @@
       example = lib.literalExpression "./my-photo.jpg";
       description = ''
         Path to user profile photo/avatar image.
-        Used by display managers (GDM) and AccountsService.
+        Used by the login greeter (DankGreeter) and AccountsService.
 
         Requires hyprflake.user.username to be set.
         Photo will be copied to /var/lib/AccountsService/icons/


### PR DESCRIPTION
> [!IMPORTANT]
> Not set to auto-merge. Review and merge manually.

Refs #19: replace GDM outright with DankMaterialShell's greetd greeter.

## Summary

GDM is removed. DankGreeter (greetd) is the only login manager. It is core infrastructure with no enable option, the same as the DMS shell itself: always present, always the login path. The login screen and the shell share one Stylix-controlled theme via the greeter's `configHome` copy, keyring auto-unlock rides on the `greetd` PAM service, and the GDM 50 / gnome-session workaround stack is deleted.

There is no in-tree GDM fallback by design. Rollback is the `backup/pre-dank-baseline` branch or a previous NixOS generation (confirmed acceptable: this is NixOS, the boot menu is the floor).

## Breaking change

`hyprflake.desktop.displayManager.enable` is removed. A login manager is core, not optional, so it no longer sits behind a toggle. Consumers that set this option will get an "unknown option" error and should drop the line. To run a different login manager, override `services.greetd` or `programs.dank-material-shell.greeter` directly.

## Changes

- **display-manager:** drop the `gdm`/`dms-greeter` enum, all GDM config (`gdm.enable`, `xserver.xkb`, `defaultSession`, the gnome-session PATH and XDG_DATA_DIRS workarounds), and the `enable` option. Configure the greeter unconditionally. `configHome` is sourced from `users.users.<name>.home` and guarded on a declared user, so a null or typo'd username degrades to the default greeter theme with a build warning, not an eval crash or a hard assertion failure (the greeter still logs you in).
- **keyring:** route `pam_gnome_keyring` to `greetd` (drop `gdm`/`gdm-password`); the `greetd` hook is now unconditional since the greeter is always the login path. `login` stays for the DMS lock screen.
- **hyprland:** repoint the `hyprpolkitagent` `ConditionGroup` guard from the GDM greeter group to the greetd greeter group (`!gdm` to `!greeter`). The greetd greeter can hit the same wl_display crash-loop, so the guard moves rather than being deleted.
- **user avatar:** `hyprflake.user.photo` already writes `/var/lib/AccountsService/icons/<username>`, which is one of the paths the greeter probes per user (`quickshell/Services/GreeterUsersService.qml`), so the login avatar is declarative with no `dms greeter sync` step. Documented in `options.md`.
- **docs:** delete the two GDM-only workarounds (gnome-session, gnome-login.session), repoint the hyprpolkitagent entry to greetd, refresh `options.md` / `architecture.md` / `keyring.md` / `workarounds.md`, drop stale GDM mentions in the user module.
- **repo:** gitignore the worktree CLI scaffolding (`.worktree-state.json`, `.worktree.lock`, `PLAN.md`) that should never be committed.

## Verified here

- `nix fmt`, `statix`, `deadnix`, `nix flake check` clean.
- Full module-tree eval (greeter + greetd + home-manager + stylix instantiated):
  - Greeter is enabled in both a fully-configured system and a bare one with no username at all (unconditional, core).
  - greetd is on, session runs as the `greeter` user.
  - `pam_gnome_keyring` is present in the generated `/etc/pam.d/greetd` (auth, session, password), so the auto-unlock hook is wired through greetd.
  - `configHome` resolves the declared home when a primary user is set, and degrades to `null` with a warning when it is not (no crash).

## Pending live verification on nixerator

This is a library flake, so the login behavior can only be confirmed on nixerator. After rebuilding with this branch, confirm:

- The greeter appears, lists the Hyprland session, login starts Hyprland, theme and avatar match the shell.
- GNOME Keyring auto-unlocks at login (login password must equal the keyring password), SSH keys load, git over SSH needs no extra passphrase.
- `hyprpolkitagent` does not crash-loop in the greeter session and runs normally in the user session (the repointed guard).

This is why the PR uses `Refs #19`, not `Closes`: keep #19 open until the live checks pass. If the greeter misbehaves, boot the previous generation or reset to `backup/pre-dank-baseline`.

## Security note (unchanged, documented)

The greeter's root `preStart` copies file paths referenced in the user's DMS `settings.json` / `session.json` into `/var/lib/dms-greeter` and makes them readable by the `greeter` user. That `customThemeFile` copy is how Stylix theming reaches the greeter, so it is load-bearing and cannot be dropped. Bounded under the single-user threat model; documented in `docs/options.md` and tracked in `docs/workarounds.md` (revisit on DMS bumps).
