### PR TITLE
feat: add DankSearch (dsearch) as the DMS launcher file-search backend

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,16 +109,22 @@ rofi, rofimoji, wlogout, hyprshell) plus hyprlock and hypridle.
   via its systemd user service (`dms.service`), and configures the idle ladder
   from `hyprflake.desktop.idle.*`.
 - The same module also imports DankSearch (`danksearch.homeModules.default`,
-  `programs.dsearch`) and enables it. dsearch is the dank ecosystem's indexed
-  filesystem search server; the DMS launcher's file search auto-detects it
-  (`command -v dsearch`, then `dsearch search --json`) and otherwise prints
-  "File search requires dsearch". Enabling the module puts `dsearch` on PATH and
-  runs `dsearch serve` as a user service, so nothing in DMS selects the backend,
-  it is detected. The index lives under `XDG_CACHE_HOME/danksearch`, not the
-  store. This is the DMS-first search backend (the dank-native server over a
-  standalone indexer); it is always-on with no hyprflake toggle, like the shell
-  itself. Roll back with `programs.dsearch.enable = lib.mkForce false` or by
-  dropping the `danksearch` input.
+  `programs.dsearch`) and enables it behind `hyprflake.desktop.search.enable`
+  (default true). dsearch is the dank ecosystem's indexed filesystem search
+  server; the DMS launcher's file search auto-detects it (`command -v dsearch`,
+  then `dsearch search --json`) and otherwise prints "File search requires
+  dsearch". Enabling the module puts `dsearch` on PATH and runs `dsearch serve`
+  as a user service, so nothing in DMS selects the backend, it is detected. The
+  index lives under `XDG_CACHE_HOME/danksearch`, not the store. This is the
+  DMS-first search backend (the dank-native server over a standalone indexer).
+  Unlike the shell, greeter, and switcher it has a toggle, because it is a
+  background daemon, not a UI surface: on first run it walks the home tree to
+  depth 6 and then holds a persistent fsnotify watch per indexed directory, so
+  on a very large home it can press against `fs.inotify.max_user_watches` and
+  carries a standing CPU/disk/battery cost. Set
+  `hyprflake.desktop.search.enable = false` to decline it (the launcher falls
+  back to its built-in path walk), or drop the `danksearch` input to remove it
+  entirely.
 - The retired waybar-stack modules and their deprecation stubs have been
   removed; their options no longer exist.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,7 +124,13 @@ rofi, rofimoji, wlogout, hyprshell) plus hyprlock and hypridle.
   carries a standing CPU/disk/battery cost. Set
   `hyprflake.desktop.search.enable = false` to decline it (the launcher falls
   back to its built-in path walk), or drop the `danksearch` input to remove it
-  entirely.
+  entirely. The unit runs `dsearch serve --socket` so the default unauthenticated
+  HTTP API on `127.0.0.1:43654` (readable by any other local user) is off; DMS
+  uses the per-user unix socket instead. The index directory is forced to
+  owner-only (0700), and the unit carries the standard kernel-surface hardening
+  (`NoNewPrivileges`, `PrivateTmp`, the `Protect*` set). `exclude_hidden` skips
+  dotdirs, but non-hidden files (including any that hold secrets) are indexed,
+  so the index aggregates that content in one owner-only place.
 - The retired waybar-stack modules and their deprecation stubs have been
   removed; their options no longer exist.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,17 @@ rofi, rofimoji, wlogout, hyprshell) plus hyprlock and hypridle.
   runs `pkgs.dms-shell` + `pkgs.quickshell` (prebuilt from nixpkgs), autostarts
   via its systemd user service (`dms.service`), and configures the idle ladder
   from `hyprflake.desktop.idle.*`.
+- The same module also imports DankSearch (`danksearch.homeModules.default`,
+  `programs.dsearch`) and enables it. dsearch is the dank ecosystem's indexed
+  filesystem search server; the DMS launcher's file search auto-detects it
+  (`command -v dsearch`, then `dsearch search --json`) and otherwise prints
+  "File search requires dsearch". Enabling the module puts `dsearch` on PATH and
+  runs `dsearch serve` as a user service, so nothing in DMS selects the backend,
+  it is detected. The index lives under `XDG_CACHE_HOME/danksearch`, not the
+  store. This is the DMS-first search backend (the dank-native server over a
+  standalone indexer); it is always-on with no hyprflake toggle, like the shell
+  itself. Roll back with `programs.dsearch.enable = lib.mkForce false` or by
+  dropping the `danksearch` input.
 - The retired waybar-stack modules and their deprecation stubs have been
   removed; their options no longer exist.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -151,8 +151,19 @@ the store. Unlike the shell it has a toggle, because it is a background daemon
 that walks the home tree (depth 6) and holds an fsnotify watch per directory, so
 on a very large home it can press against `fs.inotify.max_user_watches` and
 carries a standing CPU/disk/battery cost. Set it to `false` to fall back to the
-launcher's built-in path walk. Dotfiles and `~/.config` are not indexed
-(`exclude_hidden`); all other filenames under the home tree are.
+launcher's built-in path walk.
+
+The daemon runs socket-only (`dsearch serve --socket`), so the unauthenticated
+HTTP API it otherwise opens on `127.0.0.1:43654` is off; DMS talks to it over a
+per-user unix socket. The index directory is forced to owner-only (0700).
+Dotfiles and dotdirs are skipped (`exclude_hidden`), so `~/.ssh`, `~/.config`,
+and `~/.aws` are not indexed, but every other filename under the home tree is,
+and the contents of non-hidden text files are read for full-text search. A
+non-hidden file that holds a secret (a `secrets.nix`, a token in a `*.json` or
+`*.toml`, a credential in a `*.yml`) therefore lands in the index. The index is
+readable only by you, the same as the files it mirrors, but it does aggregate
+that content in one place, so keep real secrets in dotdirs or outside the home
+tree.
 
 ### Idle (lock / screen-off / suspend)
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -137,6 +137,23 @@ power menu, lock screen, and idle daemon. It is hyprflake's core shell and is
 always enabled — there is no toggle (one would only be needed to support
 multiple shells). It replaces the old waybar stack.
 
+### Launcher file search (DankSearch)
+
+| Option                  | Type   | Default | Description                                          |
+| ----------------------- | ------ | ------- | ---------------------------------------------------- |
+| `desktop.search.enable` | `bool` | `true`  | Run DankSearch (dsearch) as the DMS launcher backend |
+
+The DMS launcher's file search auto-detects `dsearch` (`command -v dsearch`)
+and otherwise prints "File search requires dsearch". Enabling this runs
+`dsearch serve` as a user service and puts the binary on PATH; DMS then uses it,
+no DMS setting required. The index lives under `XDG_CACHE_HOME/danksearch`, not
+the store. Unlike the shell it has a toggle, because it is a background daemon
+that walks the home tree (depth 6) and holds an fsnotify watch per directory, so
+on a very large home it can press against `fs.inotify.max_user_watches` and
+carries a standing CPU/disk/battery cost. Set it to `false` to fall back to the
+launcher's built-in path walk. Dotfiles and `~/.config` are not indexed
+(`exclude_hidden`); all other filenames under the home tree are.
+
 ### Idle (lock / screen-off / suspend)
 
 Consumed by DMS's idle daemon. Each value is in seconds; `0` disables that step.

--- a/flake.lock
+++ b/flake.lock
@@ -167,6 +167,26 @@
         "type": "github"
       }
     },
+    "danksearch": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779650358,
+        "narHash": "sha256-53a8H1NhppF1Wte4XRm78AAb23ZVOda2vlmpV4sa90U=",
+        "owner": "AvengeMedia",
+        "repo": "danksearch",
+        "rev": "e4be0825f06370d506e4755cfeae97247a18586f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AvengeMedia",
+        "repo": "danksearch",
+        "type": "github"
+      }
+    },
     "dms-emoji-launcher": {
       "flake": false,
       "locked": {
@@ -383,6 +403,7 @@
       "inputs": {
         "apple-fonts": "apple-fonts",
         "dank-material-shell": "dank-material-shell",
+        "danksearch": "danksearch",
         "dms-emoji-launcher": "dms-emoji-launcher",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",

--- a/flake.lock
+++ b/flake.lock
@@ -184,6 +184,7 @@
       "original": {
         "owner": "AvengeMedia",
         "repo": "danksearch",
+        "rev": "e4be0825f06370d506e4755cfeae97247a18586f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -63,8 +63,14 @@
     # home-manager module (programs.dsearch) in modules/desktop/dank — the
     # DMS-native, DMS-first search backend. Index lives under XDG_CACHE_HOME,
     # not the store.
+    #
+    # Pinned to a SHA, not the moving default branch, for the same reason as
+    # dank-material-shell above: dsearch is a daemon that walks the user's home
+    # and holds fsnotify watches, so an unreviewed upstream change to its walk
+    # or watch behavior should not drift in on `nix flake update`. Bump
+    # deliberately by editing this rev.
     danksearch = {
-      url = "github:AvengeMedia/danksearch";
+      url = "github:AvengeMedia/danksearch/e4be0825f06370d506e4755cfeae97247a18586f";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,18 @@
       url = "github:devnullvoid/dms-emoji-launcher/1c0a7d337a52b48f9499060076703a35e8dd4f4f";
       flake = false;
     };
+
+    # DankSearch (dsearch): the dank ecosystem's indexed filesystem search
+    # server. The DMS launcher's file search auto-detects it (DSearchService.qml
+    # runs `command -v dsearch`, then execs `dsearch search --json`); without it
+    # the launcher shows "File search requires dsearch". Consumed as a
+    # home-manager module (programs.dsearch) in modules/desktop/dank — the
+    # DMS-native, DMS-first search backend. Index lives under XDG_CACHE_HOME,
+    # not the store.
+    danksearch = {
+      url = "github:AvengeMedia/danksearch";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = { nixpkgs, ... }@flakeInputs:

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -215,6 +215,52 @@ in
             ];
           };
         };
+
+        # Run the daemon socket-only and harden it. `dsearch serve` by default
+        # also starts an UNAUTHENTICATED HTTP API on 127.0.0.1:43654: loopback,
+        # so not reachable off-host, but readable by any other local user, who
+        # could then query this user's indexed filenames and indexed file
+        # contents. DMS never uses that port; the `dsearch` CLI it execs dials
+        # the unix socket under XDG_RUNTIME_DIR (`/run/user/<uid>`, mode 0700,
+        # owner-only), so `--socket` drops the HTTP listener with no functional
+        # loss. The whole contribution is wrapped in mkIf (not just the leaf) so
+        # the toggle-off case defines no phantom dsearch unit.
+        systemd.user.services = lib.mkIf searchCfg.enable {
+          dsearch.Service = {
+            ExecStart = lib.mkForce "${lib.getExe hyprflakeInputs.danksearch.packages.${pkgs.system}.dsearch} serve --socket";
+
+            # Defense in depth: the daemon continuously parses untrusted file
+            # contents (text bodies, image EXIF) under the fsnotify watch, so
+            # shrink the kernel attack surface. Filesystem access is left wide
+            # (it must read all of $HOME and write the index under ~/.cache), and
+            # the riskier syscall/address-family filters are deferred until the
+            # service can be exercised live on nixerator.
+            NoNewPrivileges = true;
+            PrivateTmp = true;
+            ProtectKernelTunables = true;
+            ProtectKernelModules = true;
+            ProtectKernelLogs = true;
+            ProtectControlGroups = true;
+            ProtectHostname = true;
+            ProtectClock = true;
+            RestrictSUIDSGID = true;
+            RestrictRealtime = true;
+            RestrictNamespaces = true;
+            LockPersonality = true;
+            SystemCallArchitectures = "native";
+
+            # The Bleve index lives at XDG_CACHE_HOME/danksearch/index and is
+            # created with the process umask (commonly 0755 dirs / 0644 files),
+            # so on a permissive ~/.cache another local user could read indexed
+            # filenames and text bodies straight off disk, undercutting the
+            # socket-only daemon. Have systemd own the `danksearch` cache dir and
+            # force it to 0700; the 0700 parent blocks other-user traversal into
+            # the index regardless of the inner files' mode. The daemon's default
+            # index path resolves to this same dir.
+            CacheDirectory = "danksearch";
+            CacheDirectoryMode = "0700";
+          };
+        };
       })
     ];
   };

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -2,6 +2,7 @@
 
 let
   idle = config.hyprflake.desktop.idle;
+  searchCfg = config.hyprflake.desktop.search;
 in
 {
   # DankMaterialShell desktop shell. Replaces the waybar stack (bar,
@@ -13,6 +14,15 @@ in
   # toggle. A toggle would only be warranted if hyprflake supported multiple
   # shells. The idle ladder it consumes (hyprflake.desktop.idle.*) is declared
   # in modules/system/power/idle.nix.
+
+  # The shell itself is always-on, but the dsearch backend (below) gets a
+  # toggle: unlike the shell, greeter, and switcher (UI surfaces the user is
+  # looking at), it is a background daemon that walks the home directory and
+  # holds fsnotify watches, so a consumer on a huge home or a constrained
+  # laptop needs a first-class way to decline it. Defaults to on so the dank
+  # ecosystem works out of the box.
+  options.hyprflake.desktop.search.enable =
+    lib.mkEnableOption "the DankSearch (dsearch) indexed file-search backend for the DMS launcher" // { default = true; };
 
   config = {
     # External-monitor brightness (DDC over I2C) needs the i2c-dev device.
@@ -136,15 +146,16 @@ in
       # (quickshell/Services/DSearchService.qml); without it the launcher shows
       # "File search requires dsearch". Enabling the module puts `dsearch` on
       # PATH and runs `dsearch serve` as a user service, so no DMS setting
-      # selects the backend, it is detected. Always-on, no hyprflake toggle,
-      # like the DMS shell itself (DMS-first: prefer the dank-native search
-      # server over a standalone indexer). Roll back with
-      # `programs.dsearch.enable = lib.mkForce false` (launcher falls back to
-      # its built-in path walk) or by dropping the danksearch input.
+      # selects the backend, it is detected (DMS-first: prefer the dank-native
+      # search server over a standalone indexer). Gated on
+      # hyprflake.desktop.search.enable (default true); set it false and the
+      # launcher falls back to its built-in path walk. The module is imported
+      # unconditionally because it is inert when programs.dsearch.enable is
+      # false.
       hyprflakeInputs.danksearch.homeModules.default
       (_: {
         programs.dsearch = {
-          enable = true;
+          inherit (searchCfg) enable;
 
           # Declarative config so dsearch does not write its own default
           # config.toml at first run (the home-manager module only writes the
@@ -153,6 +164,15 @@ in
           # only the user's home is indexed (system paths are out of scope).
           # `~` is expanded by dsearch at runtime, so this stays portable across
           # homes (impermanence, non-standard home dirs).
+          #
+          # Scope notes: index_all_files defaults to true upstream and is left
+          # so, meaning every filename under the tree is indexed for name
+          # search; text_extensions only governs which files have their
+          # *contents* read for full-text search, it does not narrow the index.
+          # exclude_hidden = true skips dotdirs, so ~/.config and other dotfiles
+          # are not indexed; on NixOS those are mostly read-only store symlinks
+          # managed declaratively, so the loss is small. merge_default_exclude_dirs
+          # folds in the upstream skip list (.git, node_modules, target, caches).
           config = {
             index_paths = [
               {

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -129,6 +129,73 @@ in
           };
         };
       })
+
+      # DankSearch (dsearch): the dank-native indexed file-search backend the
+      # DMS launcher auto-detects. DMS runs `command -v dsearch` and, when
+      # present, execs `dsearch search --json` for launcher file search
+      # (quickshell/Services/DSearchService.qml); without it the launcher shows
+      # "File search requires dsearch". Enabling the module puts `dsearch` on
+      # PATH and runs `dsearch serve` as a user service, so no DMS setting
+      # selects the backend, it is detected. Always-on, no hyprflake toggle,
+      # like the DMS shell itself (DMS-first: prefer the dank-native search
+      # server over a standalone indexer). Roll back with
+      # `programs.dsearch.enable = lib.mkForce false` (launcher falls back to
+      # its built-in path walk) or by dropping the danksearch input.
+      hyprflakeInputs.danksearch.homeModules.default
+      (_: {
+        programs.dsearch = {
+          enable = true;
+
+          # Declarative config so dsearch does not write its own default
+          # config.toml at first run (the home-manager module only writes the
+          # file when `config != null`). index_path is left unset so it defaults
+          # to XDG_CACHE_HOME/danksearch (writable state, never the Nix store);
+          # only the user's home is indexed (system paths are out of scope).
+          # `~` is expanded by dsearch at runtime, so this stays portable across
+          # homes (impermanence, non-standard home dirs).
+          config = {
+            index_paths = [
+              {
+                path = "~";
+                max_depth = 6;
+                exclude_hidden = true;
+                merge_default_exclude_dirs = true;
+              }
+            ];
+            text_extensions = [
+              ".txt"
+              ".md"
+              ".org"
+              ".nix"
+              ".go"
+              ".py"
+              ".js"
+              ".ts"
+              ".jsx"
+              ".tsx"
+              ".json"
+              ".yaml"
+              ".yml"
+              ".toml"
+              ".html"
+              ".css"
+              ".scss"
+              ".rs"
+              ".c"
+              ".cpp"
+              ".h"
+              ".hpp"
+              ".java"
+              ".kt"
+              ".rb"
+              ".php"
+              ".sh"
+              ".fish"
+              ".lua"
+            ];
+          };
+        };
+      })
     ];
   };
 }


### PR DESCRIPTION
> [!IMPORTANT]
> PR 1 of 2 in an autonomous batch (dank ecosystem).
> This PR is **not** set to auto-merge. Review and merge manually.
> Merge in this order to avoid conflicts.
> 1. #23, DankSearch (dsearch) launcher backend
> 2. #24, dgop system monitoring (stacked on this branch)

## Summary
Closes #20: feat: add DankSearch (dsearch) as the DMS launcher file-search backend

- feat(dank): add DankSearch (dsearch) as the DMS launcher search backend
  The DMS launcher's file search auto-detects dsearch (DSearchService.qml runs
  'command -v dsearch', then execs 'dsearch search --json') and otherwise shows
  'File search requires dsearch'. Wire it as the dank-native search backend.
  
  - flake.nix: add the danksearch input (follows nixpkgs).
  - dank module: import danksearch.homeModules.default (programs.dsearch) via
    home-manager.sharedModules and enable it. Always-on, no hyprflake toggle,
    like the DMS shell. Declarative config.toml (index_paths = home,
    text_extensions) so dsearch does not write its own default at first run;
    index_path is left to default (XDG_CACHE_HOME/danksearch, never the store).
  - docs/architecture.md: document the backend and the DMS-first rationale.
  
  Enabling the module puts dsearch on PATH and runs 'dsearch serve' as a user
  service, so nothing in DMS selects the backend, it is detected. Roll back with
  programs.dsearch.enable = lib.mkForce false or by dropping the input.
