### PR TITLE
feat: enable DMS system monitoring (dgop) for the bar cpu/mem widgets

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,6 +131,13 @@ rofi, rofimoji, wlogout, hyprshell) plus hyprlock and hypridle.
   (`NoNewPrivileges`, `PrivateTmp`, the `Protect*` set). `exclude_hidden` skips
   dotdirs, but non-hidden files (including any that hold secrets) are indexed,
   so the index aggregates that content in one owner-only place.
+- The module sets `enableSystemMonitoring = true` explicitly. That feeds the bar
+  `cpuUsage`/`memUsage` widgets (and the rest of the monitoring surface) from
+  dgop, the dank-native stateless monitor, pulled from `pkgs.dgop` (nixpkgs, no
+  extra input). The DMS option already defaults to true; setting it explicitly
+  pins the contract so an upstream default change cannot silently drop the
+  widgets' backend. dgop is stateless and runs from the store. DMS-first: dgop
+  is the monitor over a standalone tool.
 - The retired waybar-stack modules and their deprecation stubs have been
   removed; their options no longer exist.
 

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -58,15 +58,13 @@ in
           # target (modules/desktop/stylix) pins currentThemeName="custom".
           enableDynamicTheming = false;
 
-          # Backend for the bar cpuUsage/memUsage widgets (and the rest of the
-          # system-monitoring surface). DMS reads metrics from dgop, the
-          # dank-native stateless monitor (CPU/mem/GPU/disk/net); enabling this
-          # adds dgop.package to the session. DMS-first: dgop is the monitor to
-          # reach for over a standalone tool. The DMS option already defaults to
-          # true, and dgop.package defaults to pkgs.dgop (nixpkgs, currently
-          # 0.2.2, no extra flake input), so this is set explicitly only to pin
-          # the contract: an upstream default flip cannot silently drop the
-          # widgets' backend. dgop is stateless and runs from the store.
+          # Backend for the bar cpuUsage/memUsage widgets: DMS reads metrics
+          # from dgop, the dank-native monitor, added to the session as
+          # pkgs.dgop (nixpkgs, no extra input). DMS-first: dgop over a
+          # standalone tool. The DMS option already defaults to true; setting it
+          # explicitly just keeps the backend pinned if that default flips.
+          # Unlike the dsearch toggle above this needs none: dgop is an
+          # on-demand CLI, no daemon, watches, or on-disk index.
           enableSystemMonitoring = true;
 
           # Emoji + unicode picker as a DMS launcher plugin (trigger ":e" in

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -58,6 +58,17 @@ in
           # target (modules/desktop/stylix) pins currentThemeName="custom".
           enableDynamicTheming = false;
 
+          # Backend for the bar cpuUsage/memUsage widgets (and the rest of the
+          # system-monitoring surface). DMS reads metrics from dgop, the
+          # dank-native stateless monitor (CPU/mem/GPU/disk/net); enabling this
+          # adds dgop.package to the session. DMS-first: dgop is the monitor to
+          # reach for over a standalone tool. The DMS option already defaults to
+          # true, and dgop.package defaults to pkgs.dgop (nixpkgs, currently
+          # 0.2.2, no extra flake input), so this is set explicitly only to pin
+          # the contract: an upstream default flip cannot silently drop the
+          # widgets' backend. dgop is stateless and runs from the store.
+          enableSystemMonitoring = true;
+
           # Emoji + unicode picker as a DMS launcher plugin (trigger ":e" in
           # spotlight). Replaces the dropped rofimoji with a DMS-native plugin
           # — pinned via the dms-emoji-launcher flake input, not installed at


### PR DESCRIPTION
> [!CAUTION]
> PR 2 of 2 in an autonomous batch (dank ecosystem). **Stacked on #23.**
>
> Before merging this PR, confirm GitHub has retargeted its base from #23's
> branch to `main`:
>
> ```bash
> gh pr view 24 --json baseRefName -q '.baseRefName'   # expect: main
> ```
>
> If it still shows the parent's branch, GitHub has not finished the
> auto-retarget yet. Wait for it, or run `gh pr edit 24 --base main` manually.
> Merging before this is a known squash-merge race that drops this PR's content
> into an unreachable commit.
>
> This PR is **not** set to auto-merge. Review and merge manually.
> Merge in this order to avoid conflicts.
> 1. #23, DankSearch (dsearch) launcher backend
> 2. #24, dgop system monitoring (stacked on #23)

## Summary
Closes #21: feat: enable DMS system monitoring (dgop) for the bar cpu/mem widgets

- feat(dank): enable DMS system monitoring (dgop) explicitly
  The bar cpuUsage/memUsage widgets read metrics from dgop via DMS's
  enableSystemMonitoring. The DMS option already defaults to true and
  dgop.package defaults to pkgs.dgop (nixpkgs 0.2.2), so the widgets already had
  a backend and no separate dgop flake input is needed. Set the option
  explicitly so an upstream default flip cannot silently drop the backend, and
  document dgop as the DMS-first, stateless system monitor (runs from the store).
  
  - dank module: enableSystemMonitoring = true with rationale.
  - docs/architecture.md: note the dgop backend and the DMS-first choice.