### PR TITLE
feat: split idle timeouts into separate AC and battery values

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -178,12 +178,12 @@ step on battery, so `0` and `null` differ: `0` is off, `null` is "same as AC".
 
 | Option                      | Type  | Default | Description                                                              |
 | --------------------------- | ----- | ------- | ------------------------------------------------------------------------ |
-| `desktop.idle.lockTimeout`  | `int` | `300`   | Seconds idle before locking the session (AC). `0` disables.             |
-| `desktop.idle.dpmsTimeout`  | `int` | `360`   | Seconds idle before turning displays off (DPMS, AC). `0` keeps the screen on. |
-| `desktop.idle.suspendTimeout` | `int` | `600`  | Seconds idle before suspend (AC). `0` disables.                          |
-| `desktop.idle.batteryLockTimeout` | `null` or `int` | `null` | Lock timeout on battery. `null` tracks `lockTimeout`; `0` disables locking on battery. |
-| `desktop.idle.batteryDpmsTimeout` | `null` or `int` | `null` | Display-off (DPMS) timeout on battery. `null` tracks `dpmsTimeout`; `0` keeps the screen on. |
-| `desktop.idle.batterySuspendTimeout` | `null` or `int` | `null` | Suspend timeout on battery. `null` tracks `suspendTimeout`; `0` disables suspend on battery. |
+| `desktop.idle.lockTimeout`  | `int ≥ 0` | `300`   | Seconds idle before locking the session (AC). `0` disables.             |
+| `desktop.idle.dpmsTimeout`  | `int ≥ 0` | `360`   | Seconds idle before turning displays off (DPMS, AC). `0` keeps the screen on. |
+| `desktop.idle.suspendTimeout` | `int ≥ 0` | `600`  | Seconds idle before suspend (AC). `0` disables.                          |
+| `desktop.idle.batteryLockTimeout` | `null` or `int ≥ 0` | `null` | Lock timeout on battery. `null` tracks `lockTimeout`; `0` disables locking on battery. |
+| `desktop.idle.batteryDpmsTimeout` | `null` or `int ≥ 0` | `null` | Display-off (DPMS) timeout on battery. `null` tracks `dpmsTimeout`; `0` keeps the screen on. |
+| `desktop.idle.batterySuspendTimeout` | `null` or `int ≥ 0` | `null` | Suspend timeout on battery. `null` tracks `suspendTimeout`; `0` disables suspend on battery. |
 
 ### Update checks
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -170,11 +170,20 @@ tree.
 Consumed by DMS's idle daemon. Each value is in seconds; `0` disables that step.
 DMS locks before suspend and honors `loginctl lock-session`.
 
+The three base options feed DMS's AC timeouts. The three `battery*` options feed
+DMS's battery timeouts; each defaults to `null`, which tracks its AC counterpart,
+so a config that sets only the base options produces the same six DMS values it
+did before (battery equals AC). An explicit `0` on a battery option disables that
+step on battery, so `0` and `null` differ: `0` is off, `null` is "same as AC".
+
 | Option                      | Type  | Default | Description                                                              |
 | --------------------------- | ----- | ------- | ------------------------------------------------------------------------ |
-| `desktop.idle.lockTimeout`  | `int` | `300`   | Seconds idle before locking the session. `0` disables.                   |
-| `desktop.idle.dpmsTimeout`  | `int` | `360`   | Seconds idle before turning displays off (DPMS). `0` keeps the screen on. |
-| `desktop.idle.suspendTimeout` | `int` | `600`  | Seconds idle before suspend. `0` disables.                               |
+| `desktop.idle.lockTimeout`  | `int` | `300`   | Seconds idle before locking the session (AC). `0` disables.             |
+| `desktop.idle.dpmsTimeout`  | `int` | `360`   | Seconds idle before turning displays off (DPMS, AC). `0` keeps the screen on. |
+| `desktop.idle.suspendTimeout` | `int` | `600`  | Seconds idle before suspend (AC). `0` disables.                          |
+| `desktop.idle.batteryLockTimeout` | `null` or `int` | `null` | Lock timeout on battery. `null` tracks `lockTimeout`; `0` disables locking on battery. |
+| `desktop.idle.batteryDpmsTimeout` | `null` or `int` | `null` | Display-off (DPMS) timeout on battery. `null` tracks `dpmsTimeout`; `0` keeps the screen on. |
+| `desktop.idle.batterySuspendTimeout` | `null` or `int` | `null` | Suspend timeout on battery. `null` tracks `suspendTimeout`; `0` disables suspend on battery. |
 
 ### Update checks
 

--- a/docs/power-management.md
+++ b/docs/power-management.md
@@ -21,6 +21,33 @@ hyprflake.desktop.idle = {
 };
 ```
 
+### AC and battery ladders
+
+DMS keeps separate idle ladders for AC and battery power. The three options
+above feed the AC ladder. To run a tighter ladder on battery, set the
+`battery*` overrides:
+
+```nix
+hyprflake.desktop.idle = {
+  # AC ladder (relaxed):
+  lockTimeout = 300;
+  dpmsTimeout = 360;
+  suspendTimeout = 600;
+
+  # Battery ladder (aggressive):
+  batteryLockTimeout = 120;     # Lock after 2 minutes on battery
+  batteryDpmsTimeout = 150;     # Screen off after 2.5 minutes on battery
+  batterySuspendTimeout = 300;  # Suspend after 5 minutes on battery
+};
+```
+
+Each `battery*` option defaults to `null`, which means "use the AC value", so a
+config that sets only the three base options runs the same ladder on both power
+sources (the prior behavior). An explicit `0` disables that step on battery, so
+`0` and `null` are not the same: `0` is off, `null` tracks AC. `batteryDpmsTimeout`
+drives DMS's `batteryMonitorTimeout`, mirroring how `dpmsTimeout` drives
+`acMonitorTimeout`.
+
 **Disable automatic suspend (desktop systems):**
 
 ```nix

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -3,6 +3,12 @@
 let
   idle = config.hyprflake.desktop.idle;
   searchCfg = config.hyprflake.desktop.search;
+
+  # Resolve a battery idle timeout: null means "track the AC value", any int
+  # (including 0, which disables the step on battery) is used as-is. DMS gets a
+  # concrete int either way. Extracted because the same fallback drives all
+  # three battery timeouts below.
+  batteryOr = batteryVal: acVal: if batteryVal != null then batteryVal else acVal;
 in
 {
   # DankMaterialShell desktop shell. Replaces the waybar stack (bar,
@@ -113,14 +119,16 @@ in
           };
 
           settings = {
-            # Idle ladder. Mirror AC and battery to the hyprflake.desktop.idle
-            # values. Seconds; 0 disables a given listener.
+            # Idle ladder. The AC settings read the hyprflake.desktop.idle
+            # values; the battery settings read the battery* overrides, each
+            # falling back to its AC counterpart when unset (batteryOr). Seconds;
+            # 0 disables a given listener. DMS's DPMS step is *MonitorTimeout.
             acLockTimeout = idle.lockTimeout;
-            batteryLockTimeout = idle.lockTimeout;
+            batteryLockTimeout = batteryOr idle.batteryLockTimeout idle.lockTimeout;
             acMonitorTimeout = idle.dpmsTimeout;
-            batteryMonitorTimeout = idle.dpmsTimeout;
+            batteryMonitorTimeout = batteryOr idle.batteryDpmsTimeout idle.dpmsTimeout;
             acSuspendTimeout = idle.suspendTimeout;
-            batterySuspendTimeout = idle.suspendTimeout;
+            batterySuspendTimeout = batteryOr idle.batterySuspendTimeout idle.suspendTimeout;
             lockBeforeSuspend = true;
             loginctlLockIntegration = true;
 

--- a/modules/system/power/idle.nix
+++ b/modules/system/power/idle.nix
@@ -33,5 +33,41 @@
       example = 0;
       description = "Seconds before suspend. 0 disables.";
     };
+
+    # Battery-specific overrides. DMS supports distinct AC and battery idle
+    # ladders; the three options above feed the AC settings, these feed the
+    # battery settings. Each defaults to null, which means "track the AC value"
+    # (resolved in the dank module), so a config that sets only the AC options
+    # behaves exactly as before. An explicit 0 disables that step on battery
+    # (DMS treats 0 and unset identically), so 0 and null are not the same here:
+    # 0 means "off on battery", null means "same as AC".
+    batteryLockTimeout = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      example = 120;
+      description = ''
+        Seconds before locking the session on battery. null tracks
+        lockTimeout (the AC value); 0 disables locking on battery.
+      '';
+    };
+    batteryDpmsTimeout = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      example = 120;
+      description = ''
+        Seconds before turning displays off (DPMS) on battery. null tracks
+        dpmsTimeout (the AC value); 0 keeps the screen on while on battery.
+        Wired to DMS's batteryMonitorTimeout.
+      '';
+    };
+    batterySuspendTimeout = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      example = 300;
+      description = ''
+        Seconds before suspend on battery. null tracks suspendTimeout (the AC
+        value); 0 disables suspend on battery.
+      '';
+    };
   };
 }

--- a/modules/system/power/idle.nix
+++ b/modules/system/power/idle.nix
@@ -9,15 +9,20 @@
 # change what consumers set.
 
 {
+  # Timeouts are seconds and never negative. The type is ints.unsigned (not
+  # plain int) so a nonsensical negative is an eval error rather than silently
+  # disabling the step: DMS's IdleService arms each listener only when its
+  # timeout is > 0, so it treats 0 and any negative the same (off). Constraining
+  # to unsigned keeps 0 as the single, documented "disable" value.
   options.hyprflake.desktop.idle = {
     lockTimeout = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.ints.unsigned;
       default = 300;
       example = 600;
       description = "Seconds before locking the session. 0 disables.";
     };
     dpmsTimeout = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.ints.unsigned;
       default = 360;
       example = 0;
       description = ''
@@ -28,7 +33,7 @@
       '';
     };
     suspendTimeout = lib.mkOption {
-      type = lib.types.int;
+      type = lib.types.ints.unsigned;
       default = 600;
       example = 0;
       description = "Seconds before suspend. 0 disables.";
@@ -42,7 +47,7 @@
     # (DMS treats 0 and unset identically), so 0 and null are not the same here:
     # 0 means "off on battery", null means "same as AC".
     batteryLockTimeout = lib.mkOption {
-      type = lib.types.nullOr lib.types.int;
+      type = lib.types.nullOr lib.types.ints.unsigned;
       default = null;
       example = 120;
       description = ''
@@ -51,9 +56,9 @@
       '';
     };
     batteryDpmsTimeout = lib.mkOption {
-      type = lib.types.nullOr lib.types.int;
+      type = lib.types.nullOr lib.types.ints.unsigned;
       default = null;
-      example = 120;
+      example = 150;
       description = ''
         Seconds before turning displays off (DPMS) on battery. null tracks
         dpmsTimeout (the AC value); 0 keeps the screen on while on battery.
@@ -61,7 +66,7 @@
       '';
     };
     batterySuspendTimeout = lib.mkOption {
-      type = lib.types.nullOr lib.types.int;
+      type = lib.types.nullOr lib.types.ints.unsigned;
       default = null;
       example = 300;
       description = ''


### PR DESCRIPTION
> [!CAUTION]
> PR 2 of 2 in an autonomous batch. **Stacked on #28.**
>
> Before merging this PR, confirm GitHub has retargeted its base from the
> parent's branch to `main`:
>
> ```bash
> gh pr view 29 --json baseRefName -q '.baseRefName'   # expect: main
> ```
>
> If it still shows the parent's branch, GitHub has not finished the
> auto-retarget yet. Wait for it, or run `gh pr edit 29 --base main`
> manually. Merging before this is a known squash-merge race that drops
> this PR's content into an unreachable commit.
>
> This PR is **not** set to auto-merge. Review and merge manually.
> Merge in this order to avoid conflicts.
> 1. #28, fix: enable DMS system sounds (add QtMultimedia to the quickshell runtime)
> 2. #29, feat: split idle timeouts into separate AC and battery values

## Summary
Closes #25: feat: split idle timeouts into separate AC and battery values

- feat(idle): split idle timeouts into separate AC and battery ladders
  DMS supports distinct AC and battery idle timeouts, but the dank module
  mirrored a single hyprflake.desktop.idle value into both. Add nullable
  batteryLockTimeout/batteryDpmsTimeout/batterySuspendTimeout options that
  default to null (track the AC value) so existing configs are unchanged,
  and wire the battery* DMS settings through a batteryOr fallback helper.
  An explicit 0 disables that step on battery. Document the split in
  docs/options.md and docs/power-management.md.
  
  Closes #25