### PR TITLE
feat(dank): add five DMS plugins (github-notifier, command-runner, calculator, battery alerts, hooks)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,6 +138,23 @@ rofi, rofimoji, wlogout, hyprshell) plus hyprlock and hypridle.
   pins the contract so an upstream default change cannot silently drop the
   widgets' backend. dgop is stateless and runs from the store. DMS-first: dgop
   is the monitor over a standalone tool.
+- The module wires a set of DMS plugins through
+  `programs.dank-material-shell.plugins.<id>`, each pinned to a SHA in a
+  `flake = false` input (bump deliberately, like the shell and dsearch pins).
+  The attr name equals the plugin's own `id` from its `plugin.json`, which is
+  what DMS links to `~/.config/DankMaterialShell/plugins/<id>` and resolves at
+  load time. `managePluginSettings = true` is required: DMS only loads a
+  non-`desktop` plugin when `plugin_settings.json` marks its id `enabled`, and
+  the home module writes that file only under this flag, so without it the
+  plugins symlink into place but never load. The set is `emojiLauncher`
+  (`:e` emoji/unicode picker, replaces rofimoji), `commandRunner` (`>` runs an
+  arbitrary shell command, a deliberate single-user exposure), `calculator`
+  (`=` evaluates and copies), `githubNotifier` (bar widget showing your open
+  PRs and assigned issues, shells out to `gh` which is added to the session and
+  needs `gh auth login` to populate), `dankHooks` (daemon running user scripts
+  on system events, inert with no hooks set), and `dankBatteryAlerts` (daemon
+  for low-battery notifications, gated on `hyprflake.system.isLaptop` like the
+  `battery` bar widget since it is pointless without a battery).
 - The retired waybar-stack modules and their deprecation stubs have been
   removed; their options no longer exist.
 

--- a/flake.lock
+++ b/flake.lock
@@ -188,6 +188,40 @@
         "type": "github"
       }
     },
+    "dms-calculator": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778511624,
+        "narHash": "sha256-hiqrO8WkzmWGVlUrzxmffUZBs4t1QM2mMTBUxZqCIyU=",
+        "owner": "rochacbruno",
+        "repo": "DankCalculator",
+        "rev": "73073d051d08254633f28f89d2609344c8289813",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rochacbruno",
+        "repo": "DankCalculator",
+        "rev": "73073d051d08254633f28f89d2609344c8289813",
+        "type": "github"
+      }
+    },
+    "dms-command-runner": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778826536,
+        "narHash": "sha256-o43IyVT901ZzZGDvZKWhlrgMba57thAoqL3+BFaFV74=",
+        "owner": "devnullvoid",
+        "repo": "dms-command-runner",
+        "rev": "35277695de06beadaba701cb94cc8b096b233319",
+        "type": "github"
+      },
+      "original": {
+        "owner": "devnullvoid",
+        "repo": "dms-command-runner",
+        "rev": "35277695de06beadaba701cb94cc8b096b233319",
+        "type": "github"
+      }
+    },
     "dms-emoji-launcher": {
       "flake": false,
       "locked": {
@@ -202,6 +236,40 @@
         "owner": "devnullvoid",
         "repo": "dms-emoji-launcher",
         "rev": "1c0a7d337a52b48f9499060076703a35e8dd4f4f",
+        "type": "github"
+      }
+    },
+    "dms-github-notifier": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776473048,
+        "narHash": "sha256-mTfqFvtlGUmIPrX8GmuNH8OfQpjDuKPwmxKmvorSLEA=",
+        "owner": "psyreactor",
+        "repo": "dms-githubNotifier",
+        "rev": "01c929dd8df3d4dcfe12bfa743eec5d096ae6fde",
+        "type": "github"
+      },
+      "original": {
+        "owner": "psyreactor",
+        "repo": "dms-githubNotifier",
+        "rev": "01c929dd8df3d4dcfe12bfa743eec5d096ae6fde",
+        "type": "github"
+      }
+    },
+    "dms-plugins": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780332225,
+        "narHash": "sha256-QkQPqP7Wmo5DLRyKNSY5NuOau4LSaSfz3DYdHDLxluA=",
+        "owner": "AvengeMedia",
+        "repo": "dms-plugins",
+        "rev": "f4583449f12920e0a2f16808b00a860c27f0173d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AvengeMedia",
+        "repo": "dms-plugins",
+        "rev": "f4583449f12920e0a2f16808b00a860c27f0173d",
         "type": "github"
       }
     },
@@ -405,7 +473,11 @@
         "apple-fonts": "apple-fonts",
         "dank-material-shell": "dank-material-shell",
         "danksearch": "danksearch",
+        "dms-calculator": "dms-calculator",
+        "dms-command-runner": "dms-command-runner",
         "dms-emoji-launcher": "dms-emoji-launcher",
+        "dms-github-notifier": "dms-github-notifier",
+        "dms-plugins": "dms-plugins",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "snappy-switcher": "snappy-switcher",

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,11 @@
     # plugins from subdirectories: DankBatteryAlerts (low-battery
     # notifications) and DankHooks (run scripts on system events). Their plugin
     # `id`s are `dankBatteryAlerts` and `dankHooks`; the attr names in
-    # modules/desktop/dank match. SHA-pinned; bump deliberately.
+    # modules/desktop/dank match. Only those two subdirs are linked into the
+    # DMS plugins dir and loaded; the rest of the monorepo (some siblings call
+    # out to api.danklinux.com) lands in the store closure but is never linked
+    # or enabled, so it cannot run. Review the whole subtree's diff on each pin
+    # bump regardless. SHA-pinned; bump deliberately.
     dms-plugins = {
       url = "github:AvengeMedia/dms-plugins/f4583449f12920e0a2f16808b00a860c27f0173d";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,43 @@
       flake = false;
     };
 
+    # DankMaterialShell bar widget: open PRs you authored and issues assigned
+    # to you, polled from GitHub via the `gh` CLI. Wired as a `githubNotifier`
+    # plugin and placed in the bar's right cluster (modules/desktop/dank). The
+    # plugin's `id` is `githubNotifier`, which must match its attr name there so
+    # DMS resolves the widget. SHA-pinned like the rest, not the moving branch;
+    # bump deliberately.
+    dms-github-notifier = {
+      url = "github:psyreactor/dms-githubNotifier/01c929dd8df3d4dcfe12bfa743eec5d096ae6fde";
+      flake = false;
+    };
+
+    # DankMaterialShell launcher plugin: run a shell command from the launcher
+    # (trigger ">"). Plugin `id` is `commandRunner`. SHA-pinned; bump
+    # deliberately.
+    dms-command-runner = {
+      url = "github:devnullvoid/dms-command-runner/35277695de06beadaba701cb94cc8b096b233319";
+      flake = false;
+    };
+
+    # DankMaterialShell launcher plugin: evaluate a math expression and copy the
+    # result (trigger "="). Plugin `id` is `calculator`; declares
+    # `requires_dms >= 1.4.0`, satisfied by the pinned DMS above. SHA-pinned.
+    dms-calculator = {
+      url = "github:rochacbruno/DankCalculator/73073d051d08254633f28f89d2609344c8289813";
+      flake = false;
+    };
+
+    # AvengeMedia's first-party DMS plugin monorepo. We consume two daemon
+    # plugins from subdirectories: DankBatteryAlerts (low-battery
+    # notifications) and DankHooks (run scripts on system events). Their plugin
+    # `id`s are `dankBatteryAlerts` and `dankHooks`; the attr names in
+    # modules/desktop/dank match. SHA-pinned; bump deliberately.
+    dms-plugins = {
+      url = "github:AvengeMedia/dms-plugins/f4583449f12920e0a2f16808b00a860c27f0173d";
+      flake = false;
+    };
+
     # DankSearch (dsearch): the dank ecosystem's indexed filesystem search
     # server. The DMS launcher's file search auto-detects it (DSearchService.qml
     # runs `command -v dsearch`, then execs `dsearch search --json`); without it

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -151,8 +151,13 @@ in
             # Launcher: run an arbitrary shell command from spotlight (trigger
             # ">"). This is a deliberate exposure decision, not a neutral
             # default: once loaded it runs whatever is typed with no further
-            # prompt (DMS enforces only the settings_write permission at
-            # runtime, not process). Acceptable here because this is a
+            # prompt. DMS does not gate plugin process execution on the
+            # `process` permission. The only permission it checks is
+            # settings_write, and only to decide whether a plugin may persist
+            # its own settings (PluginSettings.qml), not to gate code. There is
+            # no consent prompt either, so marking a plugin enabled below is the
+            # entire authorization decision, which is why the pins must be
+            # reviewed as code on every bump. Acceptable here because this is a
             # single-user workstation and the launcher already starts arbitrary
             # apps; called out so a later reader does not assume it slipped in
             # unreviewed.
@@ -169,8 +174,12 @@ in
             };
 
             # Daemon: run user scripts on system events (wallpaper/theme change,
-            # battery thresholds, and so on). Inert with no hooks configured
-            # (every hook defaults to "" and execution is guarded on non-empty).
+            # battery thresholds, and so on). It executes configured scripts
+            # even though its manifest declares no `process` permission (DMS
+            # does not enforce permissions, see commandRunner above), so do not
+            # trust the manifest's permission list when auditing what a plugin
+            # can do. Inert with no hooks configured (every hook defaults to ""
+            # and execution is guarded on non-empty), and none are set here.
             dankHooks = {
               enable = true;
               src = "${hyprflakeInputs.dms-plugins}/DankHooks";

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -109,6 +109,20 @@ in
           # on-demand CLI, no daemon, watches, or on-disk index.
           enableSystemMonitoring = true;
 
+          # Write DankMaterialShell/plugin_settings.json. DMS only loads a
+          # non-`desktop` plugin when getPluginSetting(id, "enabled", false)
+          # is true (PluginService.qml `_onManifestParsed`), and that value
+          # comes from plugin_settings.json. The DMS home module writes that
+          # file only when managePluginSettings is set; its default
+          # (hasPluginSettings) is false unless some plugin carries a non-empty
+          # `settings` attr, which none of ours do. Without this the plugins
+          # below symlink into place but never load: they sit dormant until
+          # toggled by hand in the DMS Settings UI. Forcing it on emits
+          # `{ <id> = { enabled = true; }; }` for every plugin here. The file
+          # is a read-only store symlink, consistent with settings.json above;
+          # plugins are managed declaratively, not toggled at runtime.
+          managePluginSettings = true;
+
           # DMS launcher/widget/daemon plugins. Each attr name MUST equal the
           # plugin's own `id` (from its plugin.json): the DMS home module links
           # the src tree to ~/.config/DankMaterialShell/plugins/<attr>, and DMS
@@ -124,16 +138,24 @@ in
             };
 
             # Bar widget: open PRs you authored and issues assigned to you,
-            # polled from GitHub via the `gh` CLI. Added to the bar's right
-            # cluster below. Needs `gh` on PATH and an authenticated `gh`
-            # session to show data; absent that it renders empty, it does not
-            # break the bar.
+            # polled from GitHub via the `gh` CLI every 60s. Added to the bar's
+            # right cluster below. `gh` is put on the session PATH alongside
+            # this module (home.packages); the widget still needs an
+            # authenticated `gh` session (gh auth login) to show data, and
+            # renders empty without one rather than breaking the bar.
             githubNotifier = {
               enable = true;
               src = hyprflakeInputs.dms-github-notifier;
             };
 
-            # Launcher: run a shell command from spotlight (trigger ">").
+            # Launcher: run an arbitrary shell command from spotlight (trigger
+            # ">"). This is a deliberate exposure decision, not a neutral
+            # default: once loaded it runs whatever is typed with no further
+            # prompt (DMS enforces only the settings_write permission at
+            # runtime, not process). Acceptable here because this is a
+            # single-user workstation and the launcher already starts arbitrary
+            # apps; called out so a later reader does not assume it slipped in
+            # unreviewed.
             commandRunner = {
               enable = true;
               src = hyprflakeInputs.dms-command-runner;
@@ -146,19 +168,22 @@ in
               src = hyprflakeInputs.dms-calculator;
             };
 
-            # Daemon: low-battery warning/critical notifications. Inert on
-            # desktops (no battery), so left unconditional rather than gated on
-            # isLaptop.
-            dankBatteryAlerts = {
-              enable = true;
-              src = hyprflakeInputs.dms-plugins + "/DankBatteryAlerts";
-            };
-
             # Daemon: run user scripts on system events (wallpaper/theme change,
-            # battery thresholds, and so on).
+            # battery thresholds, and so on). Inert with no hooks configured
+            # (every hook defaults to "" and execution is guarded on non-empty).
             dankHooks = {
               enable = true;
-              src = hyprflakeInputs.dms-plugins + "/DankHooks";
+              src = "${hyprflakeInputs.dms-plugins}/DankHooks";
+            };
+          }
+          # Daemon: low-battery warning/critical notifications. It reads UPower
+          # and only does anything on a host with a battery, so gate it on
+          # isLaptop the same way the `battery` bar widget below is gated,
+          # rather than installing a no-op daemon on desktops.
+          // lib.optionalAttrs config.hyprflake.system.isLaptop {
+            dankBatteryAlerts = {
+              enable = true;
+              src = "${hyprflakeInputs.dms-plugins}/DankBatteryAlerts";
             };
           };
 
@@ -238,6 +263,12 @@ in
             ];
           };
         };
+
+        # The githubNotifier bar widget shells out to `gh` (gh auth status,
+        # gh search prs/issues), defaulting to the bare `gh` on PATH. hyprflake
+        # is a module library, so do not assume the consumer happens to ship
+        # the GitHub CLI; provide it alongside the plugin that needs it.
+        home.packages = [ pkgs.gh ];
       })
 
       # DankSearch (dsearch): the dank-native indexed file-search backend the

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -109,13 +109,57 @@ in
           # on-demand CLI, no daemon, watches, or on-disk index.
           enableSystemMonitoring = true;
 
-          # Emoji + unicode picker as a DMS launcher plugin (trigger ":e" in
-          # spotlight). Replaces the dropped rofimoji with a DMS-native plugin
-          # — pinned via the dms-emoji-launcher flake input, not installed at
-          # runtime. SUPER+. opens spotlight pre-filled with the trigger.
-          plugins.emojiLauncher = {
-            enable = true;
-            src = hyprflakeInputs.dms-emoji-launcher;
+          # DMS launcher/widget/daemon plugins. Each attr name MUST equal the
+          # plugin's own `id` (from its plugin.json): the DMS home module links
+          # the src tree to ~/.config/DankMaterialShell/plugins/<attr>, and DMS
+          # loads it by id (launcher triggers, bar widget components, daemon
+          # services all key off the id). All sources are SHA-pinned flake
+          # inputs, not installed at runtime.
+          plugins = {
+            # Emoji + unicode picker (trigger ":e" in spotlight). Replaces the
+            # dropped rofimoji. SUPER+. opens spotlight pre-filled.
+            emojiLauncher = {
+              enable = true;
+              src = hyprflakeInputs.dms-emoji-launcher;
+            };
+
+            # Bar widget: open PRs you authored and issues assigned to you,
+            # polled from GitHub via the `gh` CLI. Added to the bar's right
+            # cluster below. Needs `gh` on PATH and an authenticated `gh`
+            # session to show data; absent that it renders empty, it does not
+            # break the bar.
+            githubNotifier = {
+              enable = true;
+              src = hyprflakeInputs.dms-github-notifier;
+            };
+
+            # Launcher: run a shell command from spotlight (trigger ">").
+            commandRunner = {
+              enable = true;
+              src = hyprflakeInputs.dms-command-runner;
+            };
+
+            # Launcher: evaluate a math expression and copy the result
+            # (trigger "=").
+            calculator = {
+              enable = true;
+              src = hyprflakeInputs.dms-calculator;
+            };
+
+            # Daemon: low-battery warning/critical notifications. Inert on
+            # desktops (no battery), so left unconditional rather than gated on
+            # isLaptop.
+            dankBatteryAlerts = {
+              enable = true;
+              src = hyprflakeInputs.dms-plugins + "/DankBatteryAlerts";
+            };
+
+            # Daemon: run user scripts on system events (wallpaper/theme change,
+            # battery thresholds, and so on).
+            dankHooks = {
+              enable = true;
+              src = hyprflakeInputs.dms-plugins + "/DankHooks";
+            };
           };
 
           settings = {
@@ -183,8 +227,11 @@ in
                 # - privacyIndicator: macOS-style alert shown only while the mic,
                 #   camera, or screen-share is active; invisible otherwise.
                 # Both sit by the control-center button at the right end.
+                # githubNotifier is the dms-github-notifier plugin widget,
+                # resolved by its plugin id through PluginService; it sits at
+                # the head of the right cluster next to the system tray.
                 rightWidgets =
-                  [ "systemTray" "clipboard" "cpuUsage" "memUsage" "notificationButton" ]
+                  [ "systemTray" "githubNotifier" "clipboard" "cpuUsage" "memUsage" "notificationButton" ]
                   ++ lib.optional config.hyprflake.system.isLaptop "battery"
                   ++ [ "idleInhibitor" "privacyIndicator" "controlCenterButton" ];
               }


### PR DESCRIPTION
Revives the plugin work from the closed `feat/17-dank-shell` branch, adapted to current main. Adds five DMS plugins alongside the existing `emojiLauncher`, wired through `programs.dank-material-shell.plugins`:

- `githubNotifier` (bar widget): open PRs you authored and issues assigned to you, polled via the `gh` CLI. Placed at the head of the bar's right cluster next to the system tray. Renders empty without an authenticated `gh` session, it does not break the bar.
- `commandRunner` (launcher, trigger `>`): run a shell command from spotlight.
- `calculator` (launcher, trigger `=`): evaluate an expression and copy the result. Declares `requires_dms >= 1.4.0`, satisfied by the pinned DMS.
- `dankBatteryAlerts` (daemon): low-battery warning and critical notifications. Inert on desktops, left unconditional rather than gated on `isLaptop`.
- `dankHooks` (daemon): run user scripts on system events.

Each plugin attr name matches the plugin's own `id` from its `plugin.json`, which is what the DMS home module links to `~/.config/DankMaterialShell/plugins/<id>` and what DMS resolves at load time (launcher triggers, `PluginService.getWidgetComponents()` for the bar widget, daemon services).

All four new sources are pinned to explicit revs with `flake = false`, matching the deliberate-bump pattern the `dank-material-shell` and `danksearch` inputs already follow rather than tracking a moving branch.

## Verification

Built `qbert`'s toplevel against this branch with `--override-input hyprflake`. The build is green. Confirmed in the generated home config:

- All six plugin directories link under `.config/DankMaterialShell/plugins/` (calculator, commandRunner, dankBatteryAlerts, dankHooks, emojiLauncher, githubNotifier).
- `githubNotifier` appears in `settings.json` `barConfigs[0].rightWidgets`.

`nixpkgs-fmt`, `statix`, and `deadnix` clean.