### PR TITLE
voxtype: submap is inactive under the Lua backend (convert to extraLua)

### DIFF
--- a/docs/voxtype.md
+++ b/docs/voxtype.md
@@ -12,7 +12,7 @@ Voxtype provides offline push-to-talk voice-to-text using whisper.cpp. Hold a ho
 }
 ```
 
-This installs voxtype, generates `~/.config/voxtype/config.toml`, sets up a systemd user service for the daemon, and adds a Hyprland submap for modifier suppression during text output.
+This installs voxtype, generates `~/.config/voxtype/config.toml`, and sets up a systemd user service for the daemon.
 
 ## Options
 
@@ -52,9 +52,9 @@ By default, the `threads` option is `null` and no threads setting is written to 
 
 The value should not exceed the number of physical CPU cores. Lower values reduce CPU usage; higher values speed up transcription.
 
-## Hyprland Integration
+## Compositor Integration
 
-The module ships a Hyprland submap configuration intended to suppress modifier keys during text output, which prevents compositor keybindings (like Super) from interfering when voxtype types transcribed text. It is written to `~/.config/hypr/conf.d/voxtype-submap.conf` in hyprlang syntax. Note that the Lua config backend does not load `.conf` files, so this submap is currently inactive; converting it to Lua and routing it through `hyprflake.hyprland.extraLua` is tracked in issue #32. Push-to-talk itself is unaffected because voxtype reads evdev directly.
+Push-to-talk reads the keyboard via evdev directly, so voxtype needs no Hyprland keybinding or submap wiring. Recording feedback comes from DankMaterialShell's `privacyIndicator`, which shows whenever the microphone is live.
 
 ## Common Hotkey Choices
 

--- a/docs/voxtype.md
+++ b/docs/voxtype.md
@@ -54,7 +54,7 @@ The value should not exceed the number of physical CPU cores. Lower values reduc
 
 ## Compositor Integration
 
-Push-to-talk reads the keyboard via evdev directly, so voxtype needs no Hyprland keybinding or submap wiring. Recording feedback comes from DankMaterialShell's `privacyIndicator`, which shows whenever the microphone is live.
+Push-to-talk reads the keyboard via evdev directly, so voxtype needs no Hyprland keybinding or submap wiring. If you use hyprflake's DankMaterialShell bar, its `privacyIndicator` widget shows recording feedback whenever the microphone is live.
 
 ## Common Hotkey Choices
 

--- a/modules/desktop/voxtype/default.nix
+++ b/modules/desktop/voxtype/default.nix
@@ -9,46 +9,6 @@ let
   cfg = config.hyprflake.desktop.voxtype;
 
   systemdHelpers = import ../../../lib/systemd-helpers.nix { inherit lib; };
-
-  # Map common evdev key names to Hyprland (XKB) key names
-  hyprlandKeyMap = {
-    "SCROLLLOCK" = "Scroll_Lock";
-    "INSERT" = "Insert";
-    "PAUSE" = "Pause";
-    "RIGHTALT" = "Alt_R";
-  };
-  hyprlandHotkey = hyprlandKeyMap.${lib.strings.toUpper cfg.hotkey} or cfg.hotkey;
-
-  hyprlandSubmap = pkgs.writeText "voxtype-submap.conf" ''
-    # Voxtype compositor integration
-    # Fixes modifier key interference when using compositor keybindings
-
-    # Consume the hotkey at compositor level so terminals don't receive it
-    # as input (e.g. Kitty protocol encodes it as [57359u). Voxtype reads
-    # evdev directly so push-to-talk is unaffected.
-    bind = , ${hyprlandHotkey}, exec, true
-    bindr = , ${hyprlandHotkey}, exec, true
-
-    # Recording submap - active during recording and transcription
-    # F12 cancels recording/transcription and returns to normal
-    submap = voxtype_recording
-    bind = , F12, exec, voxtype record cancel
-    bind = , F12, submap, reset
-    submap = reset
-
-    # Output submap - blocks modifier keys during text output
-    submap = voxtype_suppress
-    bind = , SUPER_L, exec, true
-    bind = , SUPER_R, exec, true
-    bind = , Control_L, exec, true
-    bind = , Control_R, exec, true
-    bind = , Alt_L, exec, true
-    bind = , Alt_R, exec, true
-    bind = , Shift_L, exec, true
-    bind = , Shift_R, exec, true
-    bind = , F12, submap, reset
-    submap = reset
-  '';
 in
 {
   options.hyprflake.desktop.voxtype = {
@@ -216,11 +176,6 @@ in
             mode = "type"
             fallback_to_clipboard = true
             type_delay_ms = 0
-            # Lua-backend dispatch syntax: hyprctl dispatch evals as
-            # hl.dispatch(...). Legacy `submap voxtype_suppress` parses
-            # wrong; use hl.dsp.submap("...") instead.
-            pre_output_command = "hyprctl dispatch 'hl.dsp.submap(\"voxtype_suppress\")'"
-            post_output_command = "hyprctl dispatch 'hl.dsp.submap(\"reset\")'"
 
             [output.notification]
             on_recording_start = false
@@ -229,18 +184,10 @@ in
           '';
         in
         {
-          # Voxtype configuration
+          # Voxtype configuration. Push-to-talk reads evdev directly, so no
+          # Hyprland keybinding or submap wiring is needed. DankMaterialShell's
+          # privacyIndicator shows when the microphone is live.
           xdg.configFile."voxtype/config.toml".source = configToml;
-
-          # Hyprland submap for modifier suppression during output.
-          # NOTE: this is hyprlang `.conf` syntax. The Lua config backend never
-          # loaded `.conf` files (the conf.d loader was `*.lua` only and is now
-          # removed), so this submap is currently inactive. Converting it to Lua
-          # and routing it through hyprflake.hyprland.extraLua is tracked in #32;
-          # it needs a hyprlang-to-Lua rewrite plus live push-to-talk testing,
-          # which is out of scope for the loader migration. Push-to-talk itself
-          # is unaffected (voxtype reads evdev directly).
-          xdg.configFile."hypr/conf.d/voxtype-submap.conf".source = hyprlandSubmap;
 
           # Systemd user service for the daemon
           systemd.user.services.voxtype = systemdHelpers.mkGraphicalUserService {


### PR DESCRIPTION
## Summary
Closes #32: voxtype: submap is inactive under the Lua backend (convert to extraLua)

- refactor(voxtype): remove obsolete inactive Hyprland submap
  The modifier-suppression submap was written as a hyprlang .conf to
  hypr/conf.d/, which the Lua config backend never loaded (#18 removed the
  conf.d loader). It has been inactive since the Lua migration.

  Rather than convert it to extraLua, drop it. DankMaterialShell's
  privacyIndicator now provides recording feedback, push-to-talk reads
  evdev directly, and the modifier interference the submap guarded against
  is not observed in practice. The voxtype_recording submap was vestigial
  (nothing dispatched it) and the config.toml pre/post_output_command
  dispatched into a submap that no longer exists.

  Removes the keymap helpers, the hyprlandSubmap writeText, the conf.d
  write, and the output-command dispatch. Updates docs/voxtype.md.

- docs(voxtype): scope the privacyIndicator feedback note to the DMS bar.

## Notes
The evdev-to-XKB hotkey translation table (hyprlandKeyMap, mapping SCROLLLOCK
to Scroll_Lock and so on) is intentionally removed along with the submap. It
only ever fed the submap binds. The voxtype config.toml [hotkey] key field
takes the evdev name directly, so dropping the table changes no behavior and
breaks no consumer setting hyprflake.desktop.voxtype.hotkey.

Closes #32