### PR TITLE
chore(flake): bump SHA-pinned DMS ecosystem inputs

### DIFF
--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -117,7 +117,7 @@ says it's safe to remove.
 
 ---
 
-## DankMaterialShell pinned to a master commit for Lua dispatch (active)
+## DankMaterialShell pinned ahead of nixpkgs for Lua dispatch (active)
 
 - **Symptom:** clicking a workspace in the DMS bar and selecting a window
   from the overview/exposé silently do nothing. DMS logs show
@@ -126,18 +126,16 @@ says it's safe to remove.
 - **Cause:** DMS talks to the Hyprland IPC socket directly (via Quickshell),
   bypassing `system/hyprctl-compat`. Under the Lua config backend Hyprland
   evaluates dispatch requests as Lua, so the legacy `workspace N` /
-  `focuswindow …` strings that nixpkgs' `dms-shell` (1.4.6) sends fail to
-  parse — the same root cause as the resolved waybar entry above. DMS fixed
-  it on `master` (1.5-beta): `HyprlandService.qml` emits `hl.dsp.*` Lua-form
-  dispatch. No release tag carries the fix yet (latest is v1.4.6).
-- **Fix:** `flake.nix` pins `dank-material-shell` to a frozen master commit
-  (a SHA, not the `master` branch, so `nix flake update` can't drift it), and
+  `focuswindow …` strings that nixpkgs' `dms-shell` sends fail to parse — the
+  same root cause as the resolved waybar entry above. DMS fixed it in the
+  `v1.5.0` release: `HyprlandService.qml` emits `hl.dsp.*` Lua-form dispatch.
+  nixpkgs' `dms-shell` still ships `v1.4.6`, which lacks the fix.
+- **Fix:** `flake.nix` pins `dank-material-shell` to the `v1.5.0` tag, and
   `modules/desktop/dank/default.nix` consumes
   `…packages.<system>.dms-shell` from that input instead of `pkgs.dms-shell`.
   Quickshell stays on nixpkgs (the DMS flake no longer ships it).
-- **Upstream:** fixed in DMS `master`; no issue to file. Track releases for
-  when the fix ships in a tag.
-- **Remove when:** a DMS *release* carries the `hl.dsp.*` dispatch — check
-  with `just dms-check`. Then pin that tag in `flake.nix`; once nixpkgs'
-  `dms-shell` reaches it, restore `package = pkgs.dms-shell` and drop both the
-  flake-package override and the master pin.
+- **Upstream:** fixed in DMS `v1.5.0`; no issue to file. Track when nixpkgs'
+  `dms-shell` catches up.
+- **Remove when:** nixpkgs' `dms-shell` reaches `v1.5.0` — check with `just
+  dms-check`. Then restore `package = pkgs.dms-shell` and drop both the
+  flake-package override and this pin.

--- a/flake.lock
+++ b/flake.lock
@@ -153,17 +153,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1781714784,
-        "narHash": "sha256-8fho6GLoZnYwv0Si/fFVYxwBHYqpcaBrb+WLFIXfoTk=",
+        "lastModified": 1783529634,
+        "narHash": "sha256-zdHsPGPE5MVi/y+uIt548XScTfZjQzdF21dME7ISEJM=",
         "owner": "AvengeMedia",
         "repo": "DankMaterialShell",
-        "rev": "29f19b07a9ff75dfc465701050e418b7c493b0f8",
+        "rev": "bdfd565b72cbb416441a9ab828efcac4fd516c70",
         "type": "github"
       },
       "original": {
         "owner": "AvengeMedia",
+        "ref": "v1.5.0",
         "repo": "DankMaterialShell",
-        "rev": "29f19b07a9ff75dfc465701050e418b7c493b0f8",
         "type": "github"
       }
     },
@@ -174,68 +174,68 @@
         ]
       },
       "locked": {
-        "lastModified": 1779650358,
-        "narHash": "sha256-53a8H1NhppF1Wte4XRm78AAb23ZVOda2vlmpV4sa90U=",
+        "lastModified": 1782736090,
+        "narHash": "sha256-TnoKATODjWk4e1w3VhRYLWGMdXMJzDyvQF8mtD6WRGA=",
         "owner": "AvengeMedia",
         "repo": "danksearch",
-        "rev": "e4be0825f06370d506e4755cfeae97247a18586f",
+        "rev": "1269b4688cc94cbd271e1cbbf19a6e7caa2293de",
         "type": "github"
       },
       "original": {
         "owner": "AvengeMedia",
         "repo": "danksearch",
-        "rev": "e4be0825f06370d506e4755cfeae97247a18586f",
+        "rev": "1269b4688cc94cbd271e1cbbf19a6e7caa2293de",
         "type": "github"
       }
     },
     "dms-calculator": {
       "flake": false,
       "locked": {
-        "lastModified": 1778511624,
-        "narHash": "sha256-hiqrO8WkzmWGVlUrzxmffUZBs4t1QM2mMTBUxZqCIyU=",
+        "lastModified": 1782146268,
+        "narHash": "sha256-j8C62+sevr6b+akzVSAqUVysIhb6Vbr8jnWcTXeOtE8=",
         "owner": "rochacbruno",
         "repo": "DankCalculator",
-        "rev": "73073d051d08254633f28f89d2609344c8289813",
+        "rev": "1db5865419a40a33171a475855a59e0b8bf7187f",
         "type": "github"
       },
       "original": {
         "owner": "rochacbruno",
         "repo": "DankCalculator",
-        "rev": "73073d051d08254633f28f89d2609344c8289813",
+        "rev": "1db5865419a40a33171a475855a59e0b8bf7187f",
         "type": "github"
       }
     },
     "dms-command-runner": {
       "flake": false,
       "locked": {
-        "lastModified": 1778826536,
-        "narHash": "sha256-o43IyVT901ZzZGDvZKWhlrgMba57thAoqL3+BFaFV74=",
+        "lastModified": 1783139331,
+        "narHash": "sha256-3dWzbyFh+5VygSTgMAVR+hn5ltv8GFMsX0EdW/lXdqw=",
         "owner": "devnullvoid",
         "repo": "dms-command-runner",
-        "rev": "35277695de06beadaba701cb94cc8b096b233319",
+        "rev": "5c2cab404335ceb96c60cf9e97a9682994209cd4",
         "type": "github"
       },
       "original": {
         "owner": "devnullvoid",
         "repo": "dms-command-runner",
-        "rev": "35277695de06beadaba701cb94cc8b096b233319",
+        "rev": "5c2cab404335ceb96c60cf9e97a9682994209cd4",
         "type": "github"
       }
     },
     "dms-emoji-launcher": {
       "flake": false,
       "locked": {
-        "lastModified": 1776309741,
-        "narHash": "sha256-NQ14YenDiNK2VqXQ3z7jAkatbSRtYJHhOhvv7AJlUD8=",
+        "lastModified": 1783139331,
+        "narHash": "sha256-fmIddCvACwO8wbAtLBMtDnEXXQJjb7+o2s4jW3f8VIU=",
         "owner": "devnullvoid",
         "repo": "dms-emoji-launcher",
-        "rev": "1c0a7d337a52b48f9499060076703a35e8dd4f4f",
+        "rev": "8ff394e3ddfcb2fd755ed2e7b4c6f01f3e26e596",
         "type": "github"
       },
       "original": {
         "owner": "devnullvoid",
         "repo": "dms-emoji-launcher",
-        "rev": "1c0a7d337a52b48f9499060076703a35e8dd4f4f",
+        "rev": "8ff394e3ddfcb2fd755ed2e7b4c6f01f3e26e596",
         "type": "github"
       }
     },
@@ -259,17 +259,17 @@
     "dms-plugins": {
       "flake": false,
       "locked": {
-        "lastModified": 1780332225,
-        "narHash": "sha256-QkQPqP7Wmo5DLRyKNSY5NuOau4LSaSfz3DYdHDLxluA=",
+        "lastModified": 1783532508,
+        "narHash": "sha256-17qZKvH0FDQEdX07HEfUjLLvOUEHGmXMVZ0zRtKoTZA=",
         "owner": "AvengeMedia",
         "repo": "dms-plugins",
-        "rev": "f4583449f12920e0a2f16808b00a860c27f0173d",
+        "rev": "5e4038806d8f4ca1fcfd1116c211cc9f1e36a074",
         "type": "github"
       },
       "original": {
         "owner": "AvengeMedia",
         "repo": "dms-plugins",
-        "rev": "f4583449f12920e0a2f16808b00a860c27f0173d",
+        "rev": "5e4038806d8f4ca1fcfd1116c211cc9f1e36a074",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -35,24 +35,23 @@
     };
 
     dank-material-shell = {
-      # Pinned to a specific master commit, NOT the moving `master` branch.
-      # The Lua-config dispatch fix (HyprlandService.qml emits `hl.dsp.*`
-      # instead of legacy `workspace N`, which Hyprland's Lua config rejects)
-      # is not in any release tag yet — the latest, v1.4.6, lacks it. Freezing
-      # the SHA stops `nix flake update` from drifting onto unreviewed master
-      # commits; bumping is then a deliberate edit. Run `just dms-check` to see
-      # when a *release* carries the fix; at that point pin the tag here and
-      # restore `package = pkgs.dms-shell` in modules/desktop/dank. The shell
-      # package is consumed from this input (see modules/desktop/dank); the
-      # home module always was. See docs/workarounds.md.
-      url = "github:AvengeMedia/DankMaterialShell/29f19b07a9ff75dfc465701050e418b7c493b0f8";
+      # Pinned to the v1.5.0 release tag, which carries the Lua-config
+      # dispatch fix (HyprlandService.qml emits `hl.dsp.*` instead of legacy
+      # `workspace N`, which Hyprland's Lua config rejects). nixpkgs'
+      # `dms-shell` still ships v1.4.6, which lacks the fix, so this input
+      # stays pinned and its `dms-shell` package is consumed here (see
+      # modules/desktop/dank) instead of `pkgs.dms-shell`. Run `just
+      # dms-check` to see when nixpkgs catches up to v1.5.0; at that point
+      # restore `package = pkgs.dms-shell` and drop this override. See
+      # docs/workarounds.md.
+      url = "github:AvengeMedia/DankMaterialShell/v1.5.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # DankMaterialShell launcher plugin: emoji + unicode picker (trigger ":e").
     # Replaces the dropped rofimoji as a DMS-native plugin. Not a flake.
     dms-emoji-launcher = {
-      url = "github:devnullvoid/dms-emoji-launcher/1c0a7d337a52b48f9499060076703a35e8dd4f4f";
+      url = "github:devnullvoid/dms-emoji-launcher/8ff394e3ddfcb2fd755ed2e7b4c6f01f3e26e596";
       flake = false;
     };
 
@@ -71,7 +70,7 @@
     # (trigger ">"). Plugin `id` is `commandRunner`. SHA-pinned; bump
     # deliberately.
     dms-command-runner = {
-      url = "github:devnullvoid/dms-command-runner/35277695de06beadaba701cb94cc8b096b233319";
+      url = "github:devnullvoid/dms-command-runner/5c2cab404335ceb96c60cf9e97a9682994209cd4";
       flake = false;
     };
 
@@ -79,7 +78,7 @@
     # result (trigger "="). Plugin `id` is `calculator`; declares
     # `requires_dms >= 1.4.0`, satisfied by the pinned DMS above. SHA-pinned.
     dms-calculator = {
-      url = "github:rochacbruno/DankCalculator/73073d051d08254633f28f89d2609344c8289813";
+      url = "github:rochacbruno/DankCalculator/1db5865419a40a33171a475855a59e0b8bf7187f";
       flake = false;
     };
 
@@ -93,7 +92,7 @@
     # or enabled, so it cannot run. Review the whole subtree's diff on each pin
     # bump regardless. SHA-pinned; bump deliberately.
     dms-plugins = {
-      url = "github:AvengeMedia/dms-plugins/f4583449f12920e0a2f16808b00a860c27f0173d";
+      url = "github:AvengeMedia/dms-plugins/5e4038806d8f4ca1fcfd1116c211cc9f1e36a074";
       flake = false;
     };
 
@@ -111,7 +110,7 @@
     # or watch behavior should not drift in on `nix flake update`. Bump
     # deliberately by editing this rev.
     danksearch = {
-      url = "github:AvengeMedia/danksearch/e4be0825f06370d506e4755cfeae97247a18586f";
+      url = "github:AvengeMedia/danksearch/1269b4688cc94cbd271e1cbbf19a6e7caa2293de";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
## Summary
- dank-material-shell: pin bumped from a frozen master commit to the `v1.5.0` release tag, which carries the Lua-config dispatch fix `docs/workarounds.md` was waiting on. nixpkgs' `dms-shell` is still on 1.4.6, so the flake-package override stays in place.
- dms-command-runner, dms-emoji-launcher, dms-calculator: bumped to latest upstream commit; diffs are trivial (funding-config metadata moves, LICENSE/README).
- dms-plugins: bumped to latest upstream commit; reviewed the full diff, it's entirely KDEConnect-plugin work and does not touch the DankBatteryAlerts or DankHooks subdirs hyprflake consumes.
- danksearch: bumped to latest upstream commit, which fixes `index_all_files = false` indexing nothing (was an unconditional check bug), plus a dependency and vendorHash update.
- dms-github-notifier: already at latest, no change.
- Updated `docs/workarounds.md` to reflect the DMS pin now tracking a release tag instead of a master SHA.

## Test plan
- [x] `nix flake lock` relocked cleanly against the new pinned URLs
- [x] `nix flake check` — all checks pass
- [x] `nix eval .#nixosModules.default` — module evaluates successfully
- [x] `nixpkgs-fmt --check` — no reformatting needed
- [x] `statix check` / `deadnix` — clean
- [ ] Pick up in nixerator via `just qu` and verify DMS 1.5.0 + plugins on a real rebuild