### PR TITLE
feat(justfile): add bump-hyprflake to bump and publish all inputs

### DIFF
--- a/justfile
+++ b/justfile
@@ -80,6 +80,29 @@ bump input="":
     git --no-pager diff -- flake.nix flake.lock
     exit "$rc"
 
+# Bring all hyprflake inputs current (bump pins + update branches), validate, then commit + push to main.
+bump-hyprflake:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "==> Bumping tag/SHA-pinned inputs"
+    just bump
+    echo "==> Updating branch-tracking inputs"
+    just update
+    if git diff --quiet -- flake.nix flake.lock; then
+      echo "hyprflake inputs already current — nothing to push."
+      exit 0
+    fi
+    echo "==> Validating (nix flake check)"
+    just check
+    echo "==> Committing + pushing"
+    git add flake.nix flake.lock
+    git commit -qS -m "chore(flake): bump inputs to latest"
+    if [ "$(git branch --show-current 2>/dev/null)" = "main" ]; then
+      git push -q origin main && echo "Pushed to origin/main."
+    else
+      echo "Committed on $(git branch --show-current) — push manually."
+    fi
+
 # Show current input versions
 inputs:
     @echo "Current flake inputs:"


### PR DESCRIPTION
Adds a single `just bump-hyprflake` recipe that brings every flake input current in one go:

- Tag/SHA-pinned inputs get bumped via `just bump`, branch-tracking inputs via `just update`.
- Validates the result with `nix flake check` before publishing.
- Commits and pushes `flake.nix` + `flake.lock` to main.

Safe to run anytime. If nothing changed, it exits early without a commit. It only auto-pushes when you're on main; otherwise it commits and tells you to push yourself.

The commit message is static (`chore(flake): bump inputs to latest`) so the recipe can run unattended.