### PR TITLE
chore(dank): restore pkgs.dms-shell now that nixpkgs shipped v1.5.0

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -319,14 +319,12 @@ step on battery, so `0` and `null` differ: `0` is off, `null` is "same as AC".
 ### Update checks
 
 A systemd user timer that surfaces, on the workstation, when a newer
-DankMaterialShell, Hyprland, dms-emoji-launcher, or Voxtype is available. DMS
-is pinned to a master commit until a release carries the Lua-config dispatch
-fix (see `docs/workarounds.md`); this flags when that release lands, when
-Hyprland moves upstream of the nixpkgs build, when the emoji-launcher pin has a
-newer commit, and when Voxtype tags a new release. It polls GitHub's public
-API, sends a DMS notification, and prints a one-line notice in interactive fish
-sessions. The on-demand command is `hyprflake-updates`; the flake-repo analog
-is `just dms-check`.
+DankMaterialShell, Hyprland, dms-emoji-launcher, or Voxtype is available. It
+flags when a pinned input has a newer upstream release/commit, when Hyprland
+moves upstream of the nixpkgs build, when the emoji-launcher pin has a newer
+commit, and when Voxtype tags a new release. It polls GitHub's public API,
+sends a DMS notification, and prints a one-line notice in interactive fish
+sessions. The on-demand command is `hyprflake-updates`.
 
 | Option                          | Type   | Default   | Description                                                       |
 | ------------------------------- | ------ | --------- | ----------------------------------------------------------------- |

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -117,25 +117,19 @@ says it's safe to remove.
 
 ---
 
-## DankMaterialShell pinned ahead of nixpkgs for Lua dispatch (active)
+## DankMaterialShell pinned ahead of nixpkgs for Lua dispatch (RESOLVED)
 
-- **Symptom:** clicking a workspace in the DMS bar and selecting a window
-  from the overview/exposé silently do nothing. DMS logs show
-  `Dispatch request "workspace 3" failed ... return hl.dispatch(workspace 3)
-  ... ')' expected near '3'`.
-- **Cause:** DMS talks to the Hyprland IPC socket directly (via Quickshell),
-  bypassing `system/hyprctl-compat`. Under the Lua config backend Hyprland
-  evaluates dispatch requests as Lua, so the legacy `workspace N` /
-  `focuswindow …` strings that nixpkgs' `dms-shell` sends fail to parse — the
-  same root cause as the resolved waybar entry above. DMS fixed it in the
-  `v1.5.0` release: `HyprlandService.qml` emits `hl.dsp.*` Lua-form dispatch.
-  nixpkgs' `dms-shell` still ships `v1.4.6`, which lacks the fix.
-- **Fix:** `flake.nix` pins `dank-material-shell` to the `v1.5.0` tag, and
-  `modules/desktop/dank/default.nix` consumes
-  `…packages.<system>.dms-shell` from that input instead of `pkgs.dms-shell`.
-  Quickshell stays on nixpkgs (the DMS flake no longer ships it).
-- **Upstream:** fixed in DMS `v1.5.0`; no issue to file. Track when nixpkgs'
-  `dms-shell` catches up.
-- **Remove when:** nixpkgs' `dms-shell` reaches the pinned version — the
-  `hyprflake-updates` timer now flags this automatically; then drop the
-  `dank-material-shell` input override and restore `package = pkgs.dms-shell`.
+- **Resolved when nixpkgs' `dms-shell` reached `v1.5.0`.**
+  `modules/desktop/dank/default.nix` now sets `package = pkgs.dms-shell`
+  again, and the `hyprflake-updates` "drop the override" check and the
+  `just dms-check` recipe were removed. The `dank-material-shell` input
+  stays pinned to `v1.5.0` for its home-manager module and greeter
+  nixosModule; only the package moved back to nixpkgs.
+- Historical context: DMS talks to the Hyprland IPC socket directly (via
+  Quickshell), bypassing `system/hyprctl-compat`. Under the Lua config
+  backend Hyprland evaluates dispatch requests as Lua, so the legacy
+  `workspace N` / `focuswindow …` strings that nixpkgs' `dms-shell` (then
+  `v1.4.6`) sent failed to parse — the same root cause as the resolved
+  waybar entry above. DMS fixed it in `v1.5.0`: `HyprlandService.qml` emits
+  `hl.dsp.*` Lua-form dispatch. hyprflake carried the `v1.5.0` package from
+  the flake input until nixpkgs caught up.

--- a/flake.nix
+++ b/flake.nix
@@ -35,15 +35,13 @@
     };
 
     dank-material-shell = {
-      # Pinned to the v1.5.0 release tag, which carries the Lua-config
-      # dispatch fix (HyprlandService.qml emits `hl.dsp.*` instead of legacy
-      # `workspace N`, which Hyprland's Lua config rejects). nixpkgs'
-      # `dms-shell` still ships v1.4.6, which lacks the fix, so this input
-      # stays pinned and its `dms-shell` package is consumed here (see
-      # modules/desktop/dank) instead of `pkgs.dms-shell`. Run `just
-      # dms-check` to see when nixpkgs catches up to v1.5.0; at that point
-      # restore `package = pkgs.dms-shell` and drop this override. See
-      # docs/workarounds.md.
+      # Pinned to the v1.5.0 release tag. This input provides the DMS
+      # home-manager module (modules/desktop/dank) and the greeter nixosModule
+      # (modules/default.nix). The dms-shell *package* now comes from nixpkgs
+      # (`pkgs.dms-shell`), which has caught up to v1.5.0 and carries the
+      # Lua-config dispatch fix that once forced consuming the package from
+      # here. Bump this pin with `just bump dank-material-shell` when a newer
+      # DMS release is out; the hyprflake-updates timer flags that.
       url = "github:AvengeMedia/DankMaterialShell/v1.5.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };

--- a/justfile
+++ b/justfile
@@ -116,31 +116,6 @@ show:
 info:
     nix flake metadata
 
-# Flag when a DMS release carries the Lua-config dispatch fix.
-# dank-material-shell is pinned to a master commit because no release tag
-# has the fix yet (HyprlandService.qml emitting hl.dsp.* dispatch). This
-# compares the pinned rev against the latest release and reports whether
-# the release contains the fix, so the pin can move to a tag.
-# See docs/workarounds.md.
-dms-check:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    repo="AvengeMedia/DankMaterialShell"
-    pinned=$(jq -r '.nodes."dank-material-shell".locked.rev' flake.lock)
-    latest=$(gh api "repos/$repo/releases/latest" --jq .tag_name)
-    echo "Pinned DMS rev : ${pinned:0:12} (master)"
-    echo "Latest release : $latest"
-    if gh api "repos/$repo/contents/quickshell/Services/HyprlandService.qml?ref=$latest" \
-         --jq '.content' | base64 -d | grep -q 'hl.dsp.focus'; then
-      echo ""
-      echo "RELEASE $latest CONTAINS the Lua dispatch fix."
-      echo "Action: pin '$repo/$latest' in flake.nix, and once nixpkgs ships"
-      echo "$latest restore 'package = pkgs.dms-shell' in modules/desktop/dank."
-    else
-      echo ""
-      echo "Release $latest does NOT yet contain the fix. Stay on the master pin."
-    fi
-
 # === Changelog Management ===
 
 # Generate/update CHANGELOG.md for unreleased changes

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -284,18 +284,15 @@ in
           programs.dank-material-shell = {
             enable = true;
 
-            # Shell built from the dank-material-shell flake input (DMS master /
-            # 1.5-beta), not nixpkgs. nixpkgs' dms-shell (1.4.6) ships the
-            # pre-Lua dispatch QML: HyprlandService.qml sends legacy
-            # `dispatch workspace N` strings, which Hyprland's Lua config
-            # evaluates as Lua and rejects, so clicking a workspace and picking
-            # a window from the overview both silently fail. Master's
-            # HyprlandService.qml emits `hl.dsp.*` Lua-form dispatch and fixes
-            # it. The dispatch string is built in this shell package, so only it
-            # needs to move; revert to pkgs.dms-shell once the fix is in a
-            # tagged release. Quickshell stays on nixpkgs — the DMS flake no
-            # longer ships it and points back at nixpkgs' build.
-            package = hyprflakeInputs.dank-material-shell.packages.${pkgs.system}.dms-shell;
+            # Shell from nixpkgs. It once came from the dank-material-shell
+            # input because nixpkgs' dms-shell (1.4.6) shipped the pre-Lua
+            # dispatch QML — HyprlandService.qml sent legacy `workspace N`
+            # strings that Hyprland's Lua config rejected — while the input's
+            # v1.5.0 emits `hl.dsp.*` Lua-form dispatch. nixpkgs' dms-shell has
+            # since reached v1.5.0 with the fix, so the package tracks nixpkgs
+            # again; the input is still consumed below for its home-manager
+            # module (and its greeter nixosModule elsewhere).
+            package = pkgs.dms-shell;
 
             # Add QtMultimedia to the quickshell runtime DMS launches. DMS gates
             # every system sound on AudioService.soundsAvailable, which resolves

--- a/modules/desktop/update-checks/default.nix
+++ b/modules/desktop/update-checks/default.nix
@@ -4,18 +4,15 @@
 # dms-emoji-launcher, or Voxtype is available, on the workstation that consumes
 # this flake.
 #
-# Two kinds of actionable signal: (a) a pinned input has a newer upstream
-# release/commit than what this flake currently builds - actionable via
-# `just bump`/`just update-input`; and (b) nixpkgs' `dms-shell` has caught up
-# to the pinned dank-material-shell version, so the flake-input override
-# (modules/desktop/dank) can be dropped in favour of `pkgs.dms-shell`.
-# Hyprland comes from nixpkgs, which lags upstream, so its signal is "nixpkgs
-# now ships newer than what this flake builds", not "upstream tagged a
-# release". dms-emoji-launcher is pinned to a frozen commit on its default
-# branch; Voxtype tracks release tags. A systemd user timer polls GitHub's
-# public API, writes a status file, sends a DMS notification when something is
-# actionable, and an interactive fish session prints a one-line notice. The
-# pull-side equivalent that runs in the flake repo is `just dms-check`.
+# The actionable signal: a pinned input has a newer upstream release/commit
+# than what this flake currently builds - actionable via `just bump`/`just
+# update-input`. Hyprland comes from nixpkgs, which lags upstream, so its
+# signal is "nixpkgs now ships newer than what this flake builds", not
+# "upstream tagged a release". dms-emoji-launcher is pinned to a frozen commit
+# on its default branch; Voxtype tracks release tags. A systemd user timer
+# polls GitHub's public API, writes a status file, sends a DMS notification
+# when something is actionable, and an interactive fish session prints a
+# one-line notice.
 
 let
   cfg = config.hyprflake.desktop.updateChecks;
@@ -50,11 +47,7 @@ in
         Periodically check whether a newer DankMaterialShell, Hyprland,
         dms-emoji-launcher, or Voxtype is available and surface it on the
         workstation (a DMS notification plus an interactive-shell notice).
-        Flags newer releases of pinned inputs (actionable via `just bump`),
-        and separately flags when nixpkgs' `dms-shell` has caught up to the
-        pinned DankMaterialShell version so the flake-input override can be
-        dropped in favour of `pkgs.dms-shell`. Pull-side analog: `just
-        dms-check`.
+        Flags newer releases of pinned inputs (actionable via `just bump`).
       '';
     };
 

--- a/modules/desktop/update-checks/hyprflake-updates.sh
+++ b/modules/desktop/update-checks/hyprflake-updates.sh
@@ -6,7 +6,7 @@
 # The @@...@@ tokens are substituted at Nix build time from the flake inputs
 # (modules/desktop/update-checks/default.nix). The check polls GitHub's public
 # release API (no auth); network failures are non-fatal and leave the cached
-# status file untouched. Pull-side analog in the flake repo: `just dms-check`.
+# status file untouched.
 #
 # Modes:
 #   (none)     human-readable report on stdout
@@ -45,23 +45,6 @@ if [ -n "$dms_latest" ]; then
   lat_dms="${dms_latest#v}"
   if ver_gt "$lat_dms" "$cur_dms"; then
     msgs+=("DMS release $dms_latest available (building $cur_dms) - run: just bump dank-material-shell")
-  fi
-fi
-
-# The dank-material-shell input is pinned ahead of nixpkgs' dms-shell only to
-# get a fix nixpkgs had not shipped yet. Once nixpkgs' dms-shell reaches the
-# pinned version, the flake-input override (modules/desktop/dank) can be dropped
-# in favour of pkgs.dms-shell. Read nixpkgs' version off the channel branch,
-# same pattern as the Hyprland check below.
-nixpkgs_dms="$(api "https://api.github.com/repos/NixOS/nixpkgs/contents/pkgs/by-name/dm/dms-shell/package.nix?ref=nixos-unstable" | jq -r '.content // empty' 2>/dev/null | base64 -d 2>/dev/null | grep -m1 -E '^[[:space:]]*version = "' 2>/dev/null || true)"
-nixpkgs_dms="${nixpkgs_dms#*\"}"
-nixpkgs_dms="${nixpkgs_dms%%\"*}"
-if [ -n "$nixpkgs_dms" ]; then
-  online=1
-  pin_dms="${CUR_DMS_VERSION%%+*}"
-  # nixpkgs >= pinned  <=>  NOT (pinned > nixpkgs)
-  if ! ver_gt "$pin_dms" "$nixpkgs_dms"; then
-    msgs+=("nixpkgs dms-shell $nixpkgs_dms >= pinned $pin_dms - drop the dank-material-shell override and restore pkgs.dms-shell (modules/desktop/dank).")
   fi
 fi
 

--- a/modules/desktop/update-checks/tests/notifier.bats
+++ b/modules/desktop/update-checks/tests/notifier.bats
@@ -13,13 +13,11 @@ setup() {
   # Each endpoint the stub answers is parameterized by an env var so a test can
   # make exactly one upstream look newer than the baked token and leave the rest
   # matching (silent). Defaults equal the baked tokens, so with no overrides the
-  # only actionable message is the nixpkgs dms-shell one (driven by NIXPKGS_DMS).
+  # notifier stays silent.
   cat >"$TMP/bin/curl" <<EOF
 #!/bin/sh
 for a in "\$@"; do url="\$a"; done
 case "\$url" in
-  *dms-shell/package.nix*)
-    printf '{"content":"%s"}' "\$(printf 'version = "%s";' "\${NIXPKGS_DMS:-1.5.0}" | base64 -w0)" ;;
   *DankMaterialShell*releases/latest*) printf '{"tag_name":"%s"}' "\${DMS_LATEST:-v1.5.0}" ;;
   *hyprland/package.nix*) printf '{"content":"%s"}' "\$(printf 'version = "%s";' "\${HYPR_LATEST:-0.50.0}" | base64 -w0)" ;;
   *dms-emoji-launcher*commits/HEAD*) printf '{"sha":"%s"}' "\${EMOJI_HEAD:-8ff394e}" ;;
@@ -32,43 +30,37 @@ EOF
 }
 teardown() { rm -rf "$TMP"; }
 
-@test "fires 'drop the override' when nixpkgs dms-shell >= pinned" {
-  NIXPKGS_DMS=1.5.0 run bash "$TMP/notifier.sh" --oneline
+@test "silent when everything matches the built versions" {
+  run bash "$TMP/notifier.sh" --oneline
   [ "$status" -eq 0 ]
-  grep -q 'pkgs.dms-shell' "$XDG_STATE_HOME/hyprflake/updates.txt"
-}
-
-@test "silent when nixpkgs dms-shell still behind pinned" {
-  NIXPKGS_DMS=1.4.6 run bash "$TMP/notifier.sh" --oneline
-  [ "$status" -eq 0 ]
-  ! grep -q 'pkgs.dms-shell' "$XDG_STATE_HOME/hyprflake/updates.txt" 2>/dev/null || false
+  [ ! -s "$XDG_STATE_HOME/hyprflake/updates.txt" ]
 }
 
 @test "does not emit the old unconditional 'drop the master pin' text" {
-  NIXPKGS_DMS=1.5.0 run bash "$TMP/notifier.sh"
+  run bash "$TMP/notifier.sh"
   ! printf '%s' "$output" | grep -q 'drop the hyprflake master pin'
 }
 
 @test "DMS release message names 'just bump dank-material-shell'" {
-  NIXPKGS_DMS=1.4.6 DMS_LATEST=v1.6.0 run bash "$TMP/notifier.sh"
+  DMS_LATEST=v1.6.0 run bash "$TMP/notifier.sh"
   [ "$status" -eq 0 ]
   printf '%s' "$output" | grep -q 'just bump dank-material-shell'
 }
 
 @test "Hyprland message names 'just update-input nixpkgs'" {
-  NIXPKGS_DMS=1.4.6 HYPR_LATEST=0.99.0 run bash "$TMP/notifier.sh"
+  HYPR_LATEST=0.99.0 run bash "$TMP/notifier.sh"
   [ "$status" -eq 0 ]
   printf '%s' "$output" | grep -q 'just update-input nixpkgs'
 }
 
 @test "emoji message names 'just bump dms-emoji-launcher'" {
-  NIXPKGS_DMS=1.4.6 EMOJI_HEAD=deadbeefdeadbeef run bash "$TMP/notifier.sh"
+  EMOJI_HEAD=deadbeefdeadbeef run bash "$TMP/notifier.sh"
   [ "$status" -eq 0 ]
   printf '%s' "$output" | grep -q 'just bump dms-emoji-launcher'
 }
 
 @test "Voxtype message names 'just update-input voxtype'" {
-  NIXPKGS_DMS=1.4.6 VOX_LATEST=v0.9.0 run bash "$TMP/notifier.sh"
+  VOX_LATEST=v0.9.0 run bash "$TMP/notifier.sh"
   [ "$status" -eq 0 ]
   printf '%s' "$output" | grep -q 'just update-input voxtype'
 }


### PR DESCRIPTION
Retires the DankMaterialShell package override now that nixpkgs' dms-shell has reached v1.5.0 (confirmed as 1.5.0 in the locked nixpkgs). That release carries the Lua-config dispatch fix that originally forced pinning the package to the flake input.

What changed:
- `modules/desktop/dank` sets `package = pkgs.dms-shell` again, instead of the input's dms-shell.
- The `dank-material-shell` input stays pinned to v1.5.0. It still provides the home-manager module and the greeter nixosModule, so only the package moved back to nixpkgs.
- Removed the now-obsolete tracking machinery: the hyprflake-updates "drop the override" check, the `just dms-check` recipe, and their bats tests. Added an all-silent notifier test to keep coverage.
- Marked the workarounds.md entry resolved and refreshed the stale comments in options.md, flake.nix, and the module.

Verified `pkgs.dms-shell` is 1.5.0 in the locked nixpkgs and `nix flake check` passes (module eval plus all three bats suites). The live desktop test is the next nixerator rebuild via `just bump-hyprflake`, which builds it for real and auto-reverts if anything fails to build.