### PR TITLE
feat(voxtype): VAD by default, acceleration option, fix deprecated whisper key

### DIFF
--- a/docs/voxtype.md
+++ b/docs/voxtype.md
@@ -24,6 +24,10 @@ This installs voxtype, generates `~/.config/voxtype/config.toml`, and sets up a 
 | `hotkey`       | `string`     | `"SCROLLLOCK"`      | Evdev key name for push-to-talk (use `evtest` to find names)        |
 | `model`        | `string`     | `"base.en"`         | Whisper model for transcription                                     |
 | `threads`      | `nullOr int` | `null`              | CPU threads for Whisper inference. When null, voxtype auto-detects. |
+| `vad.enable`   | `bool`       | `true`              | Drop silence-only recordings before transcription (see VAD below)   |
+| `vad.backend`  | `enum`       | `"energy"`          | VAD backend: `energy` (no model), `whisper` (Silero), or `auto`     |
+| `vad.threshold`| `float`      | `0.5`               | Speech detection threshold, `0.0` sensitive to `1.0` aggressive     |
+| `vad.minSpeechDurationMs` | `int` | `100`             | Minimum detected speech (ms) for a recording to be transcribed      |
 
 ## Whisper Models
 
@@ -37,6 +41,36 @@ This installs voxtype, generates `~/.config/voxtype/config.toml`, and sets up a 
 | `medium.en`      | Slow     | High     | ~5 GB  |
 | `large-v3`       | Slowest  | Highest  | ~10 GB |
 | `large-v3-turbo` | Moderate | Highest  | ~6 GB  |
+
+## Voice Activity Detection (unrelated / hallucinated output)
+
+If dictation occasionally types text that has nothing to do with what you said,
+that is whisper hallucinating on silence. When push-to-talk is released without
+speech, or the mic briefly captures nothing, whisper is handed near-silent audio
+and fills it with unrelated phrases from its training data. The model size does
+not matter here; a larger model hallucinates just as readily.
+
+VAD is the fix, and it is enabled by default. It rejects recordings with no
+detected speech before they ever reach whisper:
+
+```nix
+{
+  hyprflake.desktop.voxtype = {
+    enable = true;
+    vad = {
+      enable = true;        # default
+      backend = "energy";   # RMS-based, no model download needed
+      threshold = 0.5;      # lower = more sensitive to quiet speech
+    };
+  };
+}
+```
+
+The `energy` backend is the default because it needs no model file. The
+`whisper` backend (Silero VAD) is more accurate but requires
+`ggml-silero-vad.bin` under `~/.local/share/voxtype/models/`. If a soft speaker
+or low mic gain causes real speech to be dropped, lower `vad.threshold` or set
+`vad.enable = false`.
 
 ## Hardware Acceleration
 

--- a/docs/voxtype.md
+++ b/docs/voxtype.md
@@ -16,13 +16,14 @@ This installs voxtype, generates `~/.config/voxtype/config.toml`, and sets up a 
 
 ## Options
 
-| Option    | Type         | Default             | Description                                                         |
-| --------- | ------------ | ------------------- | ------------------------------------------------------------------- |
-| `enable`  | `bool`       | `false`             | Enable voxtype                                                      |
-| `package` | `package`    | voxtype flake input | The voxtype package                                                 |
-| `hotkey`  | `string`     | `"SCROLLLOCK"`      | Evdev key name for push-to-talk (use `evtest` to find names)        |
-| `model`   | `string`     | `"base.en"`         | Whisper model for transcription                                     |
-| `threads` | `nullOr int` | `null`              | CPU threads for Whisper inference. When null, voxtype auto-detects. |
+| Option         | Type         | Default             | Description                                                         |
+| -------------- | ------------ | ------------------- | ------------------------------------------------------------------- |
+| `enable`       | `bool`       | `false`             | Enable voxtype                                                      |
+| `acceleration` | `enum`       | `"cpu"`             | Inference backend: `cpu`, `vulkan`, or `rocm`                       |
+| `package`      | `package`    | variant from `acceleration` | The voxtype package (overrides `acceleration` when set)     |
+| `hotkey`       | `string`     | `"SCROLLLOCK"`      | Evdev key name for push-to-talk (use `evtest` to find names)        |
+| `model`        | `string`     | `"base.en"`         | Whisper model for transcription                                     |
+| `threads`      | `nullOr int` | `null`              | CPU threads for Whisper inference. When null, voxtype auto-detects. |
 
 ## Whisper Models
 
@@ -36,6 +37,36 @@ This installs voxtype, generates `~/.config/voxtype/config.toml`, and sets up a 
 | `medium.en`      | Slow     | High     | ~5 GB  |
 | `large-v3`       | Slowest  | Highest  | ~10 GB |
 | `large-v3-turbo` | Moderate | Highest  | ~6 GB  |
+
+## Hardware Acceleration
+
+By default voxtype runs whisper.cpp on the CPU. On a machine with a capable
+GPU, set `acceleration` to offload inference and run larger models comfortably:
+
+```nix
+{
+  hyprflake.desktop.voxtype = {
+    enable = true;
+    acceleration = "vulkan"; # or "rocm" / "cuda"
+    model = "large-v3-turbo";
+  };
+}
+```
+
+`acceleration` picks the matching variant from voxtype's flake, so consumers no
+longer need to reach into the transitive input by hand. Pick by GPU:
+
+| GPU                       | Recommended `acceleration` | Notes                                                            |
+| ------------------------- | -------------------------- | ---------------------------------------------------------------- |
+| AMD (RDNA/RDNA2/RDNA3)    | `vulkan`                   | Works out of the box; no ROCm runtime needed.                    |
+| AMD (ROCm-supported card) | `rocm`                     | Only if you already run ROCm; Vulkan is the simpler default.     |
+| Intel Arc / Xe (iGPU)     | `vulkan`                   | Needs voxtype >= 0.7.3 (fixes a Vulkan SIGILL on Intel CPUs).    |
+| NVIDIA                    | `vulkan`                   | voxtype ships no whisper.cpp CUDA build; Vulkan runs on NVIDIA.  |
+
+The GPU variants are Linux-only. On a laptop, weigh battery and thermals: a GPU
+build with `small.en` is often a better trade than a CPU build straining under
+`medium.en`. `package` still takes precedence if you set it explicitly (for a
+Parakeet or ONNX build the enum doesn't cover).
 
 ## Threads
 

--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783963347,
-        "narHash": "sha256-r376E2XpakiXwModDHIxlvB6qLq4iFVEq730vxOO4JY=",
+        "lastModified": 1784129366,
+        "narHash": "sha256-N5JiyICSeQF14x+OQebNyPpYowOT9Rs1iKyeCylSzOA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a45a7c451455a51ae740ec3bce4024b312809c29",
+        "rev": "165228b0efefc3e635e5174020c40ea64271dc25",
         "type": "github"
       },
       "original": {

--- a/modules/desktop/voxtype/default.nix
+++ b/modules/desktop/voxtype/default.nix
@@ -139,6 +139,63 @@ in
         Only used when backend is "remote".
       '';
     };
+
+    vad = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Enable Voice Activity Detection. VAD drops silence-only recordings
+          before they reach whisper, which prevents whisper from hallucinating
+          unrelated text on empty or near-silent audio (e.g. when push-to-talk
+          is released without speech, or the mic momentarily captures nothing).
+
+          On by default because it fixes a common push-to-talk failure mode.
+          Disable it if a quiet speaker or low mic gain causes real speech to be
+          dropped, or lower `vad.threshold` to make detection more sensitive.
+        '';
+      };
+
+      backend = lib.mkOption {
+        type = lib.types.enum [
+          "auto"
+          "energy"
+          "whisper"
+        ];
+        default = "energy";
+        example = "whisper";
+        description = ''
+          VAD detection backend.
+
+          - "energy": RMS-amplitude detection, needs no model file (default).
+          - "whisper": Silero VAD, more accurate but requires the
+            ggml-silero-vad.bin model present under voxtype's models dir.
+          - "auto": whisper VAD for the whisper engine, energy VAD otherwise.
+
+          "energy" is the default so the module needs no model provisioning.
+        '';
+      };
+
+      threshold = lib.mkOption {
+        type = lib.types.float;
+        default = 0.5;
+        example = 0.3;
+        description = ''
+          Speech detection threshold, 0.0 (most sensitive) to 1.0 (most
+          aggressive). Lower it if real speech is being dropped.
+        '';
+      };
+
+      minSpeechDurationMs = lib.mkOption {
+        type = lib.types.int;
+        default = 100;
+        example = 250;
+        description = ''
+          Minimum detected speech duration, in milliseconds, for a recording to
+          be transcribed. Recordings with less are treated as silence.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -202,6 +259,14 @@ in
                 remote_endpoint = "${cfg.remoteEndpoint}"
                 remote_timeout_secs = ${toString cfg.remoteTimeoutSecs}''
             }
+
+            [vad]
+            # Filter silence-only recordings so whisper can't hallucinate
+            # unrelated text on empty audio. Energy backend needs no model file.
+            enabled = ${lib.boolToString cfg.vad.enable}
+            backend = "${cfg.vad.backend}"
+            threshold = ${toString cfg.vad.threshold}
+            min_speech_duration_ms = ${toString cfg.vad.minSpeechDurationMs}
 
             [text]
             spoken_punctuation = true

--- a/modules/desktop/voxtype/default.nix
+++ b/modules/desktop/voxtype/default.nix
@@ -9,17 +9,49 @@ let
   cfg = config.hyprflake.desktop.voxtype;
 
   systemdHelpers = import ../../../lib/systemd-helpers.nix { inherit lib; };
+
+  voxtypePackages = hyprflakeInputs.voxtype.packages.${pkgs.stdenv.hostPlatform.system};
+
+  # Map a friendly acceleration name to the matching voxtype flake variant.
+  # "cpu" is the portable whisper.cpp build; the GPU variants are Linux-only
+  # and need the corresponding runtime (a Vulkan ICD or ROCm) present on the
+  # host. This spares consumers from reaching into voxtype's flake outputs by
+  # hand (e.g. inputs.hyprflake.inputs.voxtype.packages.<system>.vulkan).
+  accelerationPackage = {
+    cpu = voxtypePackages.default;
+    inherit (voxtypePackages) vulkan rocm;
+  }.${cfg.acceleration};
 in
 {
   options.hyprflake.desktop.voxtype = {
     enable = lib.mkEnableOption "Voxtype push-to-talk voice-to-text with whisper.cpp";
 
+    acceleration = lib.mkOption {
+      type = lib.types.enum [ "cpu" "vulkan" "rocm" ];
+      default = "cpu";
+      example = "vulkan";
+      description = ''
+        Hardware acceleration backend for whisper.cpp inference. Selects the
+        matching variant from voxtype's flake:
+
+        - "cpu": portable build, no GPU required (default).
+        - "vulkan": GPU acceleration via Vulkan (AMD, Intel Arc, or NVIDIA).
+        - "rocm": AMD GPU acceleration via ROCm.
+
+        voxtype ships no whisper.cpp CUDA build, so NVIDIA users should use
+        "vulkan". The GPU variants are Linux-only. Ignored when `package` is
+        set explicitly.
+      '';
+    };
+
     package = lib.mkOption {
       type = lib.types.package;
-      inherit (hyprflakeInputs.voxtype.packages.${pkgs.stdenv.hostPlatform.system}) default;
+      default = accelerationPackage;
+      defaultText = lib.literalExpression ''voxtype.packages.''${system}.<acceleration variant>'';
       description = ''
-        The voxtype package to use.
-        Defaults to the voxtype package from hyprflake's input.
+        The voxtype package to use. Defaults to the variant chosen by
+        `acceleration`. Set explicitly to override (for example, to use a
+        Parakeet or ONNX build not covered by the `acceleration` enum).
       '';
     };
 
@@ -159,7 +191,9 @@ in
             max_duration_secs = 60
 
             [whisper]
-            backend = "${cfg.backend}"
+            # voxtype renamed this key from `backend` to `mode` (the old name
+            # still parses but logs a deprecation warning). Values are unchanged.
+            mode = "${cfg.backend}"
             model = "${cfg.model}"
             language = "${cfg.language}"
             translate = false${lib.optionalString (cfg.threads != null) "\nthreads = ${toString cfg.threads}"}${


### PR DESCRIPTION
## What

Improvements aimed at two real, distinct symptoms: qbert occasionally typing text unrelated to what was said, and donkeykong's slow transcription.

### VAD on by default (fixes qbert's unrelated output)
qbert's "I dictated something, it typed something completely unrelated" is whisper hallucinating on silence: when push-to-talk is released without speech (or the mic briefly captures nothing), whisper is handed near-silent audio and invents unrelated phrases. Model size is irrelevant to this.

voxtype has a VAD feature for exactly this ("filters silence-only recordings ... Prevents Whisper hallucinations on silent audio") but ships it **off**. This PR turns it on with the `energy` backend (RMS-based, no model file needed) and exposes `vad.enable` / `vad.backend` / `vad.threshold` / `vad.minSpeechDurationMs` for tuning. Emits a `[vad]` section in `config.toml`.

### `acceleration` option
New enum `cpu` (default) / `vulkan` / `rocm`, selecting the matching variant from voxtype's flake so a consumer writes `acceleration = "vulkan"` instead of reaching into the transitive input by hand. `package` still overrides it. No whisper.cpp CUDA build exists upstream, so NVIDIA maps to `vulkan`.

### Deprecated whisper key
Generated config now writes `mode = "..."` instead of the deprecated `backend = "..."`. `WhisperConfig` keeps `backend` only as a backwards-compat alias; values unchanged.

### Lock refresh
`nix flake update` (home-manager → 07-15). voxtype is already on a current rev carrying the 0.7.1 glib-sys build fix and the 0.7.3 Intel-Vulkan SIGILL fix.

## Verification
- `nix fmt`, `statix`, `deadnix` clean; `nix eval .#nixosModules.default` succeeds.
- Confirmed `default`/`vulkan`/`rocm` variants exist for x86_64-linux at the bumped rev (no bare `cuda`).
- Confirmed `VadConfig` fields (`enabled`/`backend`/`threshold`/`min_speech_duration_ms`) and `WhisperConfig`'s `mode`/`backend` alias against upstream source.
- Rendered `[vad]` block parses as valid TOML.

## Downstream (nixerator, after merge + input bump)
- Drop the pre-0.7.0 voxtype pin (its TODO condition is now met upstream).
- qbert: `acceleration = "vulkan"`, keep `small.en` (model is not the issue; VAD is the fix).
- donkeykong: `acceleration = "vulkan"`, keep `base.en` (GPU offload + newer voxtype's hot-model caching address the delay; no model bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)