### PR TITLE
feat(rio): add opt-in Rio terminal module mirroring the kitty setup

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,10 @@ modules/
                           # Also defines hyprflake.desktop.keyboard + terminal options.
                           # Keybinds dispatch to `dms ipc` (launcher,
                           # notifications, power, lock, volume, brightness).
-    kitty/                # Terminal emulator
+    kitty/                # Terminal emulator (default; enabled by default)
+    rio/                  # Rio terminal emulator (GPU/WebGPU); opt-in
+                          # alternative to kitty. Config only — set
+                          # desktop.terminal.package = pkgs.rio to launch it.
     shortcuts-viewer/     # Keybinding cheat sheet (Stylix-themed HTML page
                           # rendered from `hyprctl binds`, opened in browser)
     snappy-switcher/      # Traditional MRU Alt+Tab window switcher (opt-in).

--- a/docs/options.md
+++ b/docs/options.md
@@ -83,6 +83,34 @@ Desktop environment behavior and input settings.
 | `desktop.keyboard.layout`  | `string` | `"us"`  | Keyboard layout (can be comma-separated: "us,de") |
 | `desktop.keyboard.variant` | `string` | `""`    | Keyboard variant (e.g., "colemak", "dvorak")      |
 
+### Terminal
+
+Kitty is the default terminal and is enabled out of the box. Rio (GPU/WebGPU,
+Kitty graphics protocol) is available as an opt-in alternative. Both modules
+provide terminal *config* only; the launcher — what `SUPER+RETURN` / `SUPER+T`,
+Nautilus "Open in Terminal", and the terminal opacity window rule use — is
+`desktop.terminal.package` (defined in the hyprland module).
+
+| Option                       | Type      | Default      | Description                                                        |
+| ---------------------------- | --------- | ------------ | ------------------------------------------------------------------ |
+| `desktop.kitty.enable`       | `bool`    | `true`       | Kitty terminal config (colours + font from Stylix)                 |
+| `desktop.rio.enable`         | `bool`    | `false`      | Rio terminal config (colours + font from Stylix's Rio target)      |
+| `desktop.terminal.package`   | `package` | `pkgs.kitty` | Terminal launched by keybinds, Nautilus, and window rules          |
+| `desktop.terminal.name`      | `string`  | package name | Terminal name for `nautilus-open-any-terminal` and window rules    |
+
+To switch from Kitty to Rio, flip all three in your consumer config:
+
+```nix
+hyprflake.desktop.rio.enable = true;
+hyprflake.desktop.kitty.enable = false;       # optional: drop kitty entirely
+hyprflake.desktop.terminal.package = pkgs.rio;
+```
+
+Colours and fonts are handled by Stylix for both. Rio has a known Stylix
+rendering quirk ([stylix#936](https://github.com/nix-community/stylix/issues/936)):
+the font can render small and the emoji fallback may be missing — override
+`programs.rio.settings.fonts` in your consumer if it bites.
+
 ### Display Manager
 
 The login manager is DankMaterialShell's greetd-based greeter (DankGreeter).

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -24,6 +24,7 @@
     ./desktop/gtk
     ./desktop/hyprland
     ./desktop/kitty
+    ./desktop/rio
     ./desktop/shortcuts-viewer
     ./desktop/snappy-switcher
     ./desktop/stylix

--- a/modules/desktop/rio/default.nix
+++ b/modules/desktop/rio/default.nix
@@ -1,0 +1,125 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.hyprflake.desktop.rio;
+in
+{
+  options.hyprflake.desktop.rio.enable = lib.mkEnableOption "Rio terminal emulator (GPU/WebGPU, Kitty graphics protocol)";
+
+  config = lib.mkIf cfg.enable {
+    # Rio terminal configuration.
+    #
+    # Colors and fonts come from Stylix's Rio target automatically (it activates
+    # whenever programs.rio is enabled), exactly as the kitty module leaves
+    # colours to Stylix. This module only sets non-theme behaviour so it mirrors
+    # the kitty setup: padding, decorations, cursor, clipboard, and the keymap.
+    #
+    # This module provides Rio's *config* only. To also launch Rio from
+    # SUPER+RETURN / SUPER+T, Nautilus "Open in Terminal", and the terminal
+    # opacity window rule, set the launcher in your consumer as well:
+    #
+    #   hyprflake.desktop.rio.enable = true;
+    #   hyprflake.desktop.kitty.enable = false;       # optional: drop kitty
+    #   hyprflake.desktop.terminal.package = pkgs.rio; # updates keybinds + rules
+    #
+    # Config schema verified against Rio 0.4.7 (rio-backend/src/config/*.rs).
+
+    home-manager.sharedModules = [
+      {
+        programs.rio = {
+          enable = true;
+
+          settings = {
+            # Don't prompt on window close (kitty: confirm_os_window_close = 0).
+            confirm-before-quit = false;
+
+            # Copy on mouse selection (kitty: copy_on_select = yes).
+            copy-on-select = true;
+
+            # 24-bit colour (kitty: environment COLORTERM = truecolor).
+            env-vars = [ "COLORTERM=truecolor" ];
+
+            # Inner padding between the terminal grid and the window edge, in px.
+            # kitty: window_padding_width = 15. Rio 0.4.7 exposes this as the
+            # top-level `margin` table (top/right/bottom/left), not padding-x/y.
+            # Values are floats: the field is f32 and the TOML parser rejects
+            # bare integers here.
+            margin = {
+              top = 15.0;
+              right = 15.0;
+              bottom = 15.0;
+              left = 15.0;
+            };
+
+            window = {
+              # kitty: hide_window_decorations = yes.
+              decorations = "Disabled";
+              # window.opacity is deliberately not set here: Stylix's Rio target
+              # sets it from stylix opacity.terminal (the same source kitty uses),
+              # and the Hyprland `opacity-terminal` window rule also applies by
+              # class. The two settings tables deep-merge, so decorations and
+              # Stylix's opacity coexist under [window].
+            };
+
+            cursor = {
+              # kitty: cursor_shape = block.
+              shape = "block";
+              # kitty: cursor_blink_interval = 0 (no blink).
+              blinking = false;
+            };
+
+            # Rio's Linux defaults already match most of the kitty keymap:
+            # ctrl+shift+{c,v} copy/paste, ctrl+shift+t new tab, ctrl+shift+w
+            # close, ctrl+shift+n new window. These entries only add the kitty
+            # bindings that Rio spells differently; Rio merges them over the
+            # defaults. Action strings and key tokens per bindings.rs / the
+            # config key parser in frontends/rioterm/src/bindings/mod.rs.
+            bindings.keys = [
+              # Font size: kitty uses ctrl+shift; Rio defaults to plain ctrl.
+              {
+                key = "=";
+                "with" = "control | shift";
+                action = "IncreaseFontSize";
+              }
+              {
+                key = "-";
+                "with" = "control | shift";
+                action = "DecreaseFontSize";
+              }
+              {
+                key = "0";
+                "with" = "control | shift";
+                action = "ResetFontSize";
+              }
+
+              # Tab switching: kitty uses ctrl+shift+arrows; Rio defaults to
+              # ctrl+Tab and ctrl+shift+[ / ].
+              {
+                key = "right";
+                "with" = "control | shift";
+                action = "SelectNextTab";
+              }
+              {
+                key = "left";
+                "with" = "control | shift";
+                action = "SelectPrevTab";
+              }
+
+              # kitty: ctrl+shift+enter = new window, ctrl+shift+q = close tab.
+              {
+                key = "return";
+                "with" = "control | shift";
+                action = "CreateWindow";
+              }
+              {
+                key = "q";
+                "with" = "control | shift";
+                action = "CloseTab";
+              }
+            ];
+          };
+        };
+      }
+    ];
+  };
+}


### PR DESCRIPTION
## What this does

Adds an opt-in Rio terminal module (`modules/desktop/rio`) as an alternative to kitty, wired the same way the kitty module is. It ships disabled, so nothing changes until a consumer turns it on.

## Why

Trialling Rio (GPU/WebGPU, keeps the Kitty graphics protocol so inline images still work) as a lighter, more modern terminal than kitty. Landing it as a defaulted-off module means it can be tried live from nixerator and reverted to kitty with one line if it doesn't stick.

## Switching to it

```nix
hyprflake.desktop.rio.enable = true;
hyprflake.desktop.kitty.enable = false;   # optional
hyprflake.desktop.terminal.package = pkgs.rio;
```

The first line gives Rio its config; the third makes `SUPER+RETURN` / `SUPER+T`, Nautilus "Open in Terminal", and the opacity window rule actually launch Rio.

## How faithful it is to the kitty config

- Colours and fonts: Stylix's Rio target, same source as kitty.
- Behaviour: 15px padding, no decorations, block cursor without blink, copy-on-select, no close confirm, truecolor.
- Keybinds: Rio's Linux defaults already match `ctrl+shift` c/v/t/w/n; only the bindings kitty spells differently are added on top (font size, arrow tab-switching, new window, close tab).

## Verification

- nixpkgs-fmt, statix, deadnix all clean.
- `nix eval .#nixosModules.default` imports the module set cleanly.
- Rendered config.toml validated as valid TOML; every key checked against Rio 0.4.7 source (`rio-backend/src/config`).
- home-manager eval confirms the settings deep-merge with the Stylix Rio target: `window.opacity` (Stylix) and `window.decorations` (this module) coexist under `[window]`, and cursor/colors/fonts do not collide.

## Known caveat

Stylix has a Rio font-size and emoji-fallback quirk ([nix-community/stylix#936](https://github.com/nix-community/stylix/issues/936)). If the font renders small, override `programs.rio.settings.fonts` in the consumer.

## Not done here

The launcher default (`hyprflake.desktop.terminal.package`) still points at kitty. Flipping the system default to Rio is a nixerator change, outside this module.
