### PR TITLE
fix(clipboard): stop wl-clip-persist from eating copied images

### DIFF
--- a/modules/desktop/wl-clip-persist/default.nix
+++ b/modules/desktop/wl-clip-persist/default.nix
@@ -15,6 +15,20 @@ in
         services.wl-clip-persist = {
           enable = true;
           clipboardType = "both";
+          # Only persist selections whose offered MIME types are all non-media.
+          # wl-clip-persist works by reading every offered type into memory and
+          # re-serving it; when it hits a read error on image/audio/video data
+          # it overwrites the clipboard with a text-only copy, which destroys a
+          # copied image before an app (e.g. Claude Code) can paste it. This
+          # negative-lookahead regex makes wl-clip-persist skip any selection
+          # offering a media type, so images pass through untouched (pastable
+          # while the source app is open) while text/code still persists.
+          # Requires fancy-regex lookahead, which wl-clip-persist bundles.
+          # See https://github.com/Linus789/wl-clip-persist#images
+          extraOptions = [
+            "--all-mime-type-regex"
+            "(?i)^(?!(?:image|audio|video|font|model)/).+"
+          ];
         };
       })
     ];


### PR DESCRIPTION
## What

Adds a MIME filter to wl-clip-persist so it stops clobbering copied images.

## The bug

`modules/desktop/wl-clip-persist` runs `wl-clip-persist --clipboard both` with no filtering. wl-clip-persist persists a selection by reading every offered MIME type into memory and re-serving it. When the image read errors, it overwrites the clipboard with a text-only version, so a copied image is gone before anything can paste it. This is the documented failure in the tool's [README](https://github.com/Linus789/wl-clip-persist#images), and it landed here in `cc56f7e`, which lines up with image paste into Claude Code breaking after it "used to work."

There is also a separate Claude Code 2.1.x paste regression reported across terminals ([anthropics/claude-code#13966](https://github.com/anthropics/claude-code/issues/13966)). This PR fixes the half that is ours.

## The fix

```
--all-mime-type-regex '(?i)^(?!(?:image|audio|video|font|model)/).+'
```

wl-clip-persist only persists a selection when *all* offered MIME types match the regex, so a selection offering `image/png` fails the match and is skipped entirely, left for the source app to serve. Text and code still persist. The negative lookahead compiles because wl-clip-persist 0.5.0 bundles fancy-regex 0.16.2.

Tradeoff (this is upstream's own recommended approach): a copied image is only pastable while its source app stays open, since it is no longer persisted after that app exits. That covers the normal paste-a-screenshot flow.

## Verification

- nixpkgs-fmt, statix, deadnix clean; `nix eval .#nixosModules.default` imports cleanly.
- home-manager eval confirms the generated ExecStart is exactly `wl-clip-persist --clipboard both --all-mime-type-regex '(?i)^(?!(?:image|audio|video|font|model)/).+'`.
- fancy-regex lookahead support confirmed present in the installed 0.5.0 binary.

## Confirm live

After `just qu`, copy a screenshot and paste into Claude Code with Ctrl+V. If it still fails, that points to the separate Claude Code regression, where Alt+V is a reported workaround.
