### PR TITLE
fix(eval): use stdenv.hostPlatform.system instead of deprecated pkgs.system

### DIFF
--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -561,7 +561,7 @@ in
         # the toggle-off case defines no phantom dsearch unit.
         systemd.user.services = lib.mkIf searchCfg.enable {
           dsearch.Service = {
-            ExecStart = lib.mkForce "${lib.getExe hyprflakeInputs.danksearch.packages.${pkgs.system}.dsearch} serve --socket";
+            ExecStart = lib.mkForce "${lib.getExe hyprflakeInputs.danksearch.packages.${pkgs.stdenv.hostPlatform.system}.dsearch} serve --socket";
 
             # Defense in depth: the daemon continuously parses untrusted file
             # contents (text bodies, image EXIF) under the fsnotify watch, so

--- a/modules/desktop/update-checks/default.nix
+++ b/modules/desktop/update-checks/default.nix
@@ -31,11 +31,11 @@ let
   # nixosModule. Tracked separately so `just bump dank-material-shell` still
   # gets flagged when a release moves those, without implying the shell moved.
   dmsPinVersion =
-    hyprflakeInputs.dank-material-shell.packages.${pkgs.system}.dms-shell.version;
+    hyprflakeInputs.dank-material-shell.packages.${pkgs.stdenv.hostPlatform.system}.dms-shell.version;
 
   emojiRev = hyprflakeInputs.dms-emoji-launcher.rev or "unknown";
   voxtypeVersion =
-    hyprflakeInputs.voxtype.packages.${pkgs.system}.default.version or "unknown";
+    hyprflakeInputs.voxtype.packages.${pkgs.stdenv.hostPlatform.system}.default.version or "unknown";
 
   updatesScript = pkgs.writeShellApplication {
     name = "hyprflake-updates";


### PR DESCRIPTION
nixpkgs turned the top-level `pkgs.system` alias into an eval-time warning on 2025-10-28 (`pkgs/top-level/aliases.nix`):

```
'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```

The dank and update-checks modules index input package sets with `${pkgs.system}`, so the warning fires on every consumer rebuild. Switched all three call sites to `${pkgs.stdenv.hostPlatform.system}`.

- `modules/desktop/dank/default.nix:564`
- `modules/desktop/update-checks/default.nix:34,38`

No behaviour change — `stdenv.hostPlatform.system` is the non-deprecated spelling of the same value. Files parse clean (`nix-instantiate --parse`).