### PR TITLE
feat(dank): fill DMS runtime dependency gaps (pactl, accounts-daemon, geoclue2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@
 - `docs/options.md` — options reference.
 - `docs/styling.md` — Stylix integration and theming.
 - `docs/dank-calendar.md` — Google Calendar in DankDash (vdirsyncer + khal); read when wiring `desktop.dank.calendar`.
+- `docs/dms-dependencies.md` — DMS runtime tools/services hyprflake must supply (home module skips `nixos.nix`); read when a DMS feature silently no-ops or on a `dank-material-shell` bump.
 - `docs/power-management.md` — TLP / PPD / sleep / lid / battery options.
 - `docs/window-rules.md` — Hyprland window rules syntax (0.53+).
 - `docs/uwsm-session.md` — how UWSM activates `graphical-session.target`, why `withUWSM` is mandatory, and the stale greeter-pin failure that kills the dank shell; read when post-login services don't start.

--- a/docs/dms-dependencies.md
+++ b/docs/dms-dependencies.md
@@ -1,0 +1,98 @@
+# DMS Runtime Dependencies
+
+The external tools and system services DankMaterialShell shells out to at
+runtime, which of them hyprflake must supply itself, and which are covered
+elsewhere or deliberately left out. Read this when a DMS feature silently no-ops
+(the surface goes inert, nothing is logged) or when auditing dependencies after a
+`dank-material-shell` bump.
+
+**Revisit on every `dank-material-shell` input bump.** New features add new
+`command -v` probes and `exec` calls, and upstream's `nixos.nix` service list can
+grow. Re-run the audit below.
+
+## Why hyprflake carries these at all
+
+hyprflake wires DMS through two upstream modules and skips a third:
+
+- `homeModules.dank-material-shell` — the shell, its plugins, and settings.
+- `nixosModules.greeter` — the DankGreeter login surface.
+- **not** `nixosModules.dank-material-shell` (`distro/nix/nixos.nix`), the shell's
+  main NixOS module.
+
+The home module pulls in DMS's runtime *packages* through `common.packages`
+(`distro/nix/common.nix`), gated on the feature toggles: `dgop` with
+`enableSystemMonitoring`, `glib` + `networkmanager` with `enableVPN` (default
+true), `matugen` with `enableDynamicTheming`, `cava` with `enableAudioWavelength`,
+`khal` with `enableCalendarEvents`. So package deps track their feature and need
+no restating.
+
+What a home-manager module cannot do is set system services. `nixos.nix` sets
+four of them `mkDefault true`, and since hyprflake never imports it, any service
+DMS needs has to be restated on hyprflake's side, or the dependent feature
+quietly no-ops. This is the same failure mode as a missing CLI tool on `PATH`.
+
+## What hyprflake supplies
+
+Tools and services DMS needs that hyprflake provides directly, because nothing
+upstream in its wiring does:
+
+| Dependency | Where | Feature |
+| --- | --- | --- |
+| `pactl` (pulseaudio) | `dank` module `home.packages` | Bluetooth codec switching (`pactl set-card-profile`); pulseaudio ships `pactl`, PipeWire does not |
+| `services.accounts-daemon` | `dank` module | Control-center user avatar (`org.freedesktop.Accounts` get/set) + greeter icon cache |
+| `services.geoclue2` | `dank` module | Night-mode sunrise/sunset auto-location + weather |
+
+The two services mirror `nixos.nix`. The other two services that module sets are
+already covered outside the `dank` module (next section), so they are not
+restated there.
+
+## Covered elsewhere (do not duplicate)
+
+| Dependency | Provided by |
+| --- | --- |
+| `security.polkit.enable` | `modules/desktop/hyprland` |
+| `services.power-profiles-daemon` | `modules/system/power`, the DMS battery-widget profile control (laptop default; TLP disabled as mutually exclusive) |
+| `wpctl` (core volume/mute path) | NixOS wireplumber module adds it to `systemPackages` |
+| `gsettings`/`glib`, `nmcli` client | DMS `home.packages` via `common.packages` (`enableVPN` default true) |
+| `dgop`, `dsearch`, `khal`, `qtmultimedia`, `libnotify`, `cliphist`, `dconf`, `hyprctl`, `uwsm` | respective modules / `common.packages` |
+
+## Deliberately absent
+
+| Dependency | Reason |
+| --- | --- |
+| `matugen` | `enableDynamicTheming = false`; Stylix owns theming |
+| `cava` | `enableAudioWavelength` off; the audio visualizer is not enabled |
+| `fprintd` | fingerprint unlock is hardware- and policy-conditional; the consumer enables `services.fprintd` |
+| U2F/FIDO2 lockscreen | opt-in `lockscreen.securityKey` in upstream `nixos.nix`, not wired |
+| NetworkManager *daemon* | the `nmcli` client is on `PATH`, but enabling the daemon is the consumer's networking policy (it can conflict); hyprflake makes no hard runtime assumption |
+
+## Auditing after a bump
+
+The dependency set lives in the DMS source tree, not in one manifest. Upstream's
+own packaging `Requires`/`Recommends` miss the graceful-degradation probes: it
+never listed `pactl`. To re-audit, resolve the input's store path and grep it:
+
+```
+p=$(nix eval --raw --impure \
+  --expr '(builtins.getFlake (toString ./.)).inputs.dank-material-shell.outPath')
+
+# optional/probed tools (degrade gracefully)
+grep -rhoE 'command -v [a-zA-Z0-9_-]+' "$p/quickshell" | sort -u
+
+# directly invoked binaries (QML)
+grep -rhoE 'command:\s*\[\s*"[a-zA-Z0-9_./-]+"' "$p/quickshell" \
+  | grep -oE '"[a-zA-Z0-9_./-]+"$' | tr -d '"' | sort -u
+grep -rhoE 'execDetached\(\s*\[\s*"[a-zA-Z0-9_./-]+"' "$p/quickshell" \
+  | grep -oE '"[a-zA-Z0-9_./-]+"$' | tr -d '"' | sort -u
+
+# system services upstream expects
+grep -n 'services\.\|security\.' "$p/distro/nix/nixos.nix"
+
+# runtime package list (per feature toggle)
+cat "$p/distro/nix/common.nix"
+```
+
+Separate genuine runtime deps from the `dms` CLI's cross-distro installer tooling
+(git, cargo, cmake, pacman, apt, flatpak, distro package managers) in `core/`;
+those install and build paths never run on NixOS. Then cross-reference the
+survivors against the tables above.

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -458,8 +458,20 @@ in
           # gh search prs/issues), defaulting to the bare `gh` on PATH. hyprflake
           # is a module library, so do not assume the consumer happens to ship
           # the GitHub CLI; provide it alongside the plugin that needs it.
+          #
+          # pactl: DMS's control-center Bluetooth codec selector probes
+          # `command -v pactl` (Services/BluetoothService.qml) and, when found,
+          # runs `pactl list cards` / `pactl set-card-profile` to switch a paired
+          # device's audio codec — each codec is exposed as a PipeWire card
+          # profile. Without pactl the selector is inert and shows "Codec
+          # switching is unavailable because pactl was not found". pactl ships
+          # only in pulseaudio (PipeWire's own package does not provide it); the
+          # bundled pulseaudio daemon stays dormant since pipewire-pulse owns the
+          # socket (services.pipewire.pulse in the hyprland module). Provided here
+          # for the same reason as gh: it is a DMS runtime dependency, so ship it
+          # alongside DMS rather than assume the consumer already has it.
           home.packages =
-            [ pkgs.gh ]
+            [ pkgs.gh pkgs.pulseaudio ]
             ++ lib.optionals cfg.capture.enable userCapture.packages;
 
           home.activation = lib.mkIf cfg.capture.enable {

--- a/modules/desktop/dank/default.nix
+++ b/modules/desktop/dank/default.nix
@@ -250,6 +250,33 @@ in
     # Internal-panel brightness goes through logind and needs nothing extra.
     hardware.i2c.enable = true;
 
+    # System services DMS expects. hyprflake drives DMS through its
+    # home-manager module plus the greeter nixosModule, deliberately NOT
+    # importing the shell's main nixosModule (distro/nix/nixos.nix). That module
+    # is where upstream sets these `mkDefault true` services, and a home-manager
+    # module cannot set system services — so without restating them here the
+    # features that depend on them silently no-op (the same failure mode as the
+    # missing pactl). The other two services nixos.nix sets are already covered:
+    # security.polkit.enable (modules/desktop/hyprland) and
+    # services.power-profiles-daemon (modules/system/power, the DMS battery
+    # widget's profile control). mkDefault so a consumer can still override.
+    services = {
+      # User account metadata over D-Bus. DMS's control-center user tile reads
+      # and writes the account avatar through org.freedesktop.Accounts
+      # (Services/PortalService.qml: freedesktop.accounts.getUserIconFile /
+      # setIconFile) and gates on the service being reachable; the greeter reads
+      # the icon cache this daemon maintains under /var/lib/AccountsService/icons.
+      # Without it the avatar can't load or be set and the greeter falls back to
+      # ~/.face.
+      accounts-daemon.enable = lib.mkDefault true;
+
+      # Geolocation over D-Bus for DMS's location-aware automation — night-mode
+      # (color-temperature) sunrise/sunset scheduling and the weather service.
+      # Without it those fall back to manual/time-based config with no auto
+      # location.
+      geoclue2.enable = lib.mkDefault true;
+    };
+
     home-manager.sharedModules = [
       hyprflakeInputs.dank-material-shell.homeModules.dank-material-shell
       # Bind `lib` from the home-manager module args so `lib.hm.dag` (the


### PR DESCRIPTION
Audited every external binary and system service DankMaterialShell shells out to at runtime, then cross-referenced against what hyprflake already provides. hyprflake drives DMS through its **home-manager module** + the **greeter nixosModule**, deliberately skipping the shell's main nixosModule (`distro/nix/nixos.nix`). A home-manager module bundles `common.packages` (so package deps like dgop/khal/glib/networkmanager/matugen are pulled in, gated on their feature toggles) but **cannot set system services** — so the four services that main module sets `mkDefault true` have to be restated by hyprflake, or they silently no-op.

## Gaps filled

| Dependency | Kind | Feature it unblocks |
|---|---|---|
| `pactl` (pulseaudio) | package (DMS `home.packages`) | Control-center **Bluetooth codec switching** (`pactl set-card-profile`) |
| `services.accounts-daemon` | system service | Control-center **user avatar** (get/set over `org.freedesktop.Accounts`) + greeter icon cache |
| `services.geoclue2` | system service | Night-mode **sunrise/sunset auto-location** + weather |

Each degrades silently when absent — DMS probes and falls back, so nothing errors; the feature just goes dead. `pactl` even surfaces *"Codec switching is unavailable because pactl was not found"* in the UI.

## Already covered (verified, no change)

- **`security.polkit.enable`** — `modules/desktop/hyprland` (the other two services from `nixos.nix`).
- **`services.power-profiles-daemon`** — `modules/system/power`; already documented as driving the DMS battery-widget profile control, TLP disabled as mutually exclusive.
- **`wpctl`** (core volume/mute) — NixOS's wireplumber module adds it to `systemPackages`.
- **`gsettings`/`glib`, `nmcli`** — pulled into DMS `home.packages` via `common.packages` (`enableVPN` defaults true).
- **`dgop`, `dsearch`, `khal`, `qtmultimedia`, `libnotify`, `cliphist`, `dconf`, `hyprctl`, `uwsm`** — all provided.
- **`matugen`** — intentionally excluded (`enableDynamicTheming = false`; Stylix owns theming).

## Out of scope / notes

- **NetworkManager daemon** — the `nmcli` client is on PATH, but the daemon itself is system networking policy left to the consumer (enabling it here could conflict). No hard runtime assumption in hyprflake (the `systemctl restart NetworkManager` reference is only example text in a power-module option doc).
- **`cava`** (audio-wavelength visualizer), **`fprintd`** (fingerprint unlock), **U2F lockscreen** — off by feature toggle or hardware-conditional; deps correctly absent.

## Verification

`deadnix` / `statix` / `nixpkgs-fmt --check` clean; `nix flake check --no-build` passes.