### PR TITLE
fix(theming): let Stylix own GTK/Qt theme env vars, not hyprland

### DIFF
--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -381,10 +381,14 @@ in
         QT_WAYLAND_DISABLE_WINDOWDECORATION = "1";
         QT_AUTO_SCREEN_SCALE_FACTOR = "1";
 
-        # Theming
-        GTK_THEME = "Adwaita:dark";
-        QT_STYLE_OVERRIDE = "adwaita-dark";
-        QT_QPA_PLATFORMTHEME = lib.mkDefault "qt5ct"; # Hyprland recommended
+        # Theming: GTK_THEME, QT_STYLE_OVERRIDE, and QT_QPA_PLATFORMTHEME are
+        # intentionally not set here. Stylix's gtk/qt home-manager targets own
+        # them (see docs/architecture.md, "Stylix stays the single source of
+        # truth"): GTK_THEME as an env var overrides settings.ini and would
+        # silently defeat Stylix's colorScheme-driven GTK theme, and
+        # QT_STYLE_OVERRIDE/QT_QPA_PLATFORMTHEME would race Stylix's own
+        # home.sessionVariables/systemd.user.sessionVariables declarations of
+        # the same vars through a different, unordered delivery path.
 
         # Cursor from hyprflake.style options
         XCURSOR_THEME = config.hyprflake.style.cursor.name;

--- a/modules/system/keyring/default.nix
+++ b/modules/system/keyring/default.nix
@@ -111,6 +111,8 @@ in
       SSH_AUTH_SOCK = "$XDG_RUNTIME_DIR/gcr/ssh";
       # Use gcr4 for graphical SSH passphrase prompts
       # Only used when no terminal is available (e.g., GUI git operations)
+      # mkForce: no other module in this tree sets SSH_ASKPASS today (verified
+      # via repo-wide grep); kept in case a future service/portal module claims it.
       SSH_ASKPASS = lib.mkForce "${pkgs.gcr_4}/libexec/gcr4-ssh-askpass";
       # Point applications to GNOME Keyring control socket
       GNOME_KEYRING_CONTROL = "$XDG_RUNTIME_DIR/keyring";


### PR DESCRIPTION
## Summary
- Removes hardcoded `GTK_THEME`/`QT_STYLE_OVERRIDE`/`QT_QPA_PLATFORMTHEME` env vars from `modules/desktop/hyprland/default.nix` that were silently overriding Stylix's theming
- `GTK_THEME` as an env var beats `settings.ini`, so it defeated Stylix's colorScheme-driven GTK theme for every native GTK app, unconditionally
- `QT_STYLE_OVERRIDE`/`QT_QPA_PLATFORMTHEME` were independently set by Stylix's `qt` home-manager target via `home.sessionVariables`/`systemd.user.sessionVariables`, a different unordered delivery path than NixOS's `environment.variables` — same hazard class as the `SSH_AUTH_SOCK` ordering bug fixed in 467441a
- Adds a clarifying comment on the pre-existing `SSH_ASKPASS = lib.mkForce` in the keyring module noting it's currently a no-op guard (verified no other module sets `SSH_ASKPASS`)

Full audit findings (including this one) are in the conversation that produced this branch.

## Test plan
- [x] `nix run nixpkgs#statix -- check .` — clean
- [x] `nix run nixpkgs#deadnix -- .` — clean
- [x] `nix eval .#nixosModules.default` — evaluates successfully
- [x] `nix flake check` — all checks pass (dank-diff-pytest, dank-seed-bats, update-checks-*-bats)
- [ ] Rebuild in nixerator (`just qu` after pointing the `hyprflake` flake input at this branch) and confirm native GTK apps (nautilus, seahorse, etc.) render the configured `hyprflake.style.colorScheme` theme instead of generic Adwaita dark, and Qt apps (e.g. anything qt5ct-themed) are unaffected