### PR TITLE
fix(snappy-switcher): tolerate upstream's /usr/bin service rename

### DIFF
--- a/modules/desktop/snappy-switcher/default.nix
+++ b/modules/desktop/snappy-switcher/default.nix
@@ -8,7 +8,31 @@
 let
   systemdHelpers = import ../../../lib/systemd-helpers.nix { inherit lib; };
 
-  package = hyprflakeInputs.snappy-switcher.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  # Upstream's own postPatch does
+  # `substituteInPlace snappy-switcher.service --replace-fail "/usr/local" "$out"`
+  # but never installs that file (installPhase has no `$out/lib/systemd/...`
+  # step -- hyprflake ships its own systemd.user.services.snappy-switcher unit
+  # below), so the substitution is dead weight. A 2026-08-06 upstream commit
+  # changed the file's ExecStart from /usr/local/bin to /usr/bin, so the
+  # pattern stopped matching and --replace-fail now hard-aborts the whole
+  # derivation build over a substitution whose result nothing consumes.
+  # Re-run postPatch with --replace-warn on that one line so a future
+  # upstream rename here can't break this build again.
+  package =
+    hyprflakeInputs.snappy-switcher.packages.${pkgs.stdenv.hostPlatform.system}.default.overrideAttrs
+      (_old: {
+        postPatch = ''
+          patchShebangs scripts/
+          substituteInPlace scripts/install-config.sh \
+            --replace-fail "/usr/local" "$out"
+          substituteInPlace scripts/snappy-wrapper.sh \
+            --replace-fail "/usr/local" "$out"
+          substituteInPlace src/config.c \
+            --replace-fail "/usr/local" "$out"
+          substituteInPlace snappy-switcher.service \
+            --replace-warn "/usr/local" "$out"
+        '';
+      });
 
   snappy = lib.getExe package;
 


### PR DESCRIPTION
## Summary
- Upstream `snappy-switcher`'s own flake.nix `postPatch` uses `--replace-fail "/usr/local" "$out"` on `snappy-switcher.service`, a file its `installPhase` never actually installs (hyprflake defines its own systemd unit for this)
- A 2026-08-06 upstream commit changed that file's `ExecStart` to `/usr/bin/snappy-switcher`, so the dead-weight substitution's pattern stopped matching and `--replace-fail` now hard-aborts the whole package build
- This blocked `nixerator`'s `just bump-hyprflake` from landing #51 (the theming fix) — the rebuild failed on `snappy-switcher-4.0.0.drv` and nixerator correctly reverted its `flake.lock` rather than switch to a broken system, but nothing landed either
- Fix: `overrideAttrs` re-runs `postPatch` with `--replace-warn` on just that one unused substitution, keeping `--replace-fail` on the three substitutions whose output actually matters (`scripts/install-config.sh`, `scripts/snappy-wrapper.sh`, `src/config.c`)

## Test plan
- [x] Built the patched package standalone (`nix build` against `inputs.snappy-switcher.packages.x86_64-linux.default.overrideAttrs`) — succeeds, `$out/bin/snappy-switcher` present
- [x] `nix eval .#nixosModules.default` — evaluates successfully
- [x] `statix check` / `deadnix` — clean
- [ ] Full `nixerator` rebuild against this branch