### PR TITLE
fix(themes): drop removed gtk-engine-murrine package

### DIFF
--- a/modules/desktop/themes/default.nix
+++ b/modules/desktop/themes/default.nix
@@ -7,11 +7,16 @@
   # (via stylix.icons and stylix.cursor in modules/desktop/stylix), so we don't
   # duplicate those here.
   #
-  # gtk-engine-murrine and gnome-themes-extra are kept for compatibility with
-  # downstream GTK themes that bypass Stylix's adw-gtk3 path. Both are small
-  # and harmless when unused.
+  # gnome-themes-extra is kept for compatibility with downstream GTK themes
+  # that bypass Stylix's adw-gtk3 path. Small and harmless when unused.
+  #
+  # gtk-engine-murrine was removed from nixpkgs 2026-07-22 (unmaintained
+  # upstream, depended on GTK2 -- pkgs.gtk-engine-murrine is now a `throw`,
+  # not a package), so it can no longer be listed here at all. Every
+  # third-party GTK theme that needed it is gone from nixpkgs for the same
+  # reason (see pkgs/top-level/aliases.nix), so there's nothing left in this
+  # tree that depends on it.
   environment.systemPackages = [
-    pkgs.gtk-engine-murrine # required by many third-party GTK themes
     pkgs.gnome-themes-extra # Adwaita and other base themes
   ];
 }


### PR DESCRIPTION
## Summary
- nixpkgs removed `gtk-engine-murrine` 2026-07-22 (unmaintained upstream, GTK2 dependency) -- it's now a `throw` in `pkgs/top-level/aliases.nix`, not a package
- Every third-party GTK theme that needed it was removed from nixpkgs for the same reason, so there's nothing left depending on it
- The routine nixpkgs bump from `just bump-hyprflake` surfaced this as a hard eval failure on `environment.systemPackages`, blocking the rebuild after #51/#52 landed
- `gnome-themes-extra` is unaffected and stays

## Test plan
- [x] `statix check` / `deadnix` -- clean
- [x] `nix eval .#nixosModules.default` -- evaluates successfully
- [ ] Full `nixerator` rebuild against this branch