### PR TITLE
fix(hyprland): pin glaze to 7.2.0 for hyprland's build only

### DIFF
--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -413,6 +413,30 @@ in
     };
 
     # Add GStreamer plugins to Nautilus for audio/video file properties
+    #
+    # PIN (remove when condition below is met): nixpkgs's hyprland-0.56.1
+    # CMake hard-requires glaze 7.2.0 (find_package(glaze) with an exact
+    # version check), but nixpkgs bumped its own top-level `glaze` package to
+    # 8.0.0 in the same update (pkgs/by-name/gl/glaze/package.nix). With that
+    # mismatch, CMake's find_package fails, Hyprland's CMakeLists.txt falls
+    # back to `FetchContent_MakeAvailable` to git-clone glaze v7.2.0 at build
+    # time, and that fetch fails inside Nix's network-sandboxed builder --
+    # `error: could not find git for clone of glaze`. This broke
+    # `nix flake update hyprflake --refresh` + rebuild in nixerator
+    # (2026-08-06, nixpkgs commit b7c2ada94fe99c15b0dbcf4d11fd7850b957a436).
+    #
+    # This overlay pins glaze back to 7.2.0 ONLY for hyprland's own build
+    # (via `.override { glaze = ...; }`, since hyprland's package.nix takes
+    # glaze as a plain function argument) -- it does NOT touch the global
+    # `pkgs.glaze`, so every other consumer of glaze still gets nixpkgs'
+    # current version and nothing else loses updates over this.
+    #
+    # Remove this override once nixpkgs re-pairs the two packages: after any
+    # future nixpkgs bump, check whether
+    # pkgs/by-name/hy/hyprland/package.nix's required glaze version matches
+    # pkgs/by-name/gl/glaze/package.nix's `version` again (or just try
+    # building `pkgs.hyprland` unpatched -- if it succeeds, the pairing is
+    # fixed upstream and this whole overlay block can go).
     nixpkgs.overlays = [
       (_final: prev: {
         nautilus = prev.nautilus.overrideAttrs (old: {
@@ -423,6 +447,18 @@ in
               gst-plugins-bad
             ]);
         });
+
+        hyprland = prev.hyprland.override {
+          glaze = prev.glaze.overrideAttrs (_old: {
+            version = "7.2.0";
+            src = prev.fetchFromGitHub {
+              owner = "stephenberry";
+              repo = "glaze";
+              tag = "v7.2.0";
+              hash = "sha256-f3NVRi3SXKo42hn0WCw7JsOK3EkdOVJIcuzhPorKjFY=";
+            };
+          });
+        };
       })
     ];
 


### PR DESCRIPTION
## Summary
- nixpkgs bumped its top-level `glaze` package to 8.0.0, but `hyprland-0.56.1`'s CMakeLists.txt hard-requires glaze 7.2.0 via `find_package`
- Version mismatch makes CMake fall back to `FetchContent_MakeAvailable`, git-cloning glaze v7.2.0 at build time -- which fails inside Nix's sandboxed builder (no network)
- This blocked `just bump-hyprflake` in nixerator after #51/#52/#53 landed
- Overrides `hyprland`'s own `glaze` buildInput to a pinned 7.2.0 build via `.override`, scoped only to hyprland -- the global `pkgs.glaze` is untouched, so nothing else loses updates
- Comment documents the exact removal condition for when nixpkgs re-pairs the two packages

## Test plan
- [x] Built pinned glaze 7.2.0 standalone -- succeeds
- [x] Built `pkgs.hyprland.override { glaze = <pinned>; }` standalone -- succeeds
- [x] `statix check` / `deadnix` -- clean
- [x] `nix eval .#nixosModules.default` -- evaluates successfully
- [ ] Full `nixerator` rebuild against this branch